### PR TITLE
feat: add DISABLE_ADMIN_PASSWORD_CHECK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ DB changes: 增加用户 `passkey` 表, 需要执行 `db/2024-08-10-patch.sql` �
 - feat: worker 增加 `DISABLE_SHOW_GITHUB` 配置, 用于配置是否显示 github 链接
 - feat: worker 增加 `NO_LIMIT_SEND_ROLE` 配置, 用于配置可以无限发送邮件的角色
 - feat: 用户增加 `passkey` 登录方式, 用于用户登录, 无需输入密码
+- feat: worker 增加 `DISABLE_ADMIN_PASSWORD_CHECK` 配置, 用于配置是否禁用 admin 控制台密码检查, 若你的网站只可私人访问，可通过此禁用检查
 
 ## v0.6.1
 

--- a/vitepress-docs/docs/en/cli.md
+++ b/vitepress-docs/docs/en/cli.md
@@ -84,6 +84,8 @@ PREFIX = "tmp" # The mailbox name prefix to be processed
 # PASSWORDS = ["123", "456"]
 # admin console password, if not configured, access to the console is not allowed
 # ADMIN_PASSWORDS = ["123", "456"]
+# warning: no password or user check for admin portal
+# DISABLE_ADMIN_PASSWORD_CHECK = false
 # admin contact information. If not configured, it will not be displayed. Any string can be configured.
 # ADMIN_CONTACT = "xx@xx.xxx"
 DEFAULT_DOMAINS = ["xxx.xxx1" , "xxx.xxx2"] # domain name for no role users

--- a/vitepress-docs/docs/zh/guide/cli/worker.md
+++ b/vitepress-docs/docs/zh/guide/cli/worker.md
@@ -52,6 +52,8 @@ PREFIX = "tmp" # 要处理的邮箱名称前缀，不需要后缀可配置为空
 # PASSWORDS = ["123", "456"]
 # admin 控制台密码, 不配置则不允许访问控制台
 # ADMIN_PASSWORDS = ["123", "456"]
+# 警告: 管理员控制台没有密码或用户检查
+# DISABLE_ADMIN_PASSWORD_CHECK = false
 # admin 联系方式，不配置则不显示，可配置任意字符串
 # ADMIN_CONTACT = "xx@xx.xxx"
 # DEFAULT_DOMAINS = ["xxx.xxx1" , "xxx.xxx2"] # 默认用户可用的域名(未登录或未分配角色的用户)

--- a/vitepress-docs/docs/zh/guide/feature/admin.md
+++ b/vitepress-docs/docs/zh/guide/feature/admin.md
@@ -9,3 +9,7 @@
 需要在后端配置 `ADMIN_PASSWORDS` 或者当前用户角色为 `ADMIN_USER_ROLE`, 则不允许访问控制台。
 
 ![admin](/feature/admin.png)
+
+## 如果你的网站只可私人访问，可通过此禁用检查
+
+`DISABLE_ADMIN_PASSWORD_CHECK = true`

--- a/worker/src/types.d.ts
+++ b/worker/src/types.d.ts
@@ -25,6 +25,7 @@ export type Bindings = {
     DOMAIN_LABELS: string | string[] | undefined
     PASSWORDS: string | string[] | undefined
     ADMIN_PASSWORDS: string | string[] | undefined
+    DISABLE_ADMIN_PASSWORD_CHECK: string | boolean | undefined
     JWT_SECRET: string
     BLACK_LIST: string | undefined
     ENABLE_AUTO_REPLY: string | boolean | undefined

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -153,6 +153,7 @@ app.use('/user_api/*', async (c, next) => {
 });
 // admin auth
 app.use('/admin/*', async (c, next) => {
+
 	// check header x-admin-auth
 	const adminPasswords = getAdminPasswords(c);
 	if (adminPasswords && adminPasswords.length > 0) {
@@ -182,6 +183,13 @@ app.use('/admin/*', async (c, next) => {
 			console.error(e);
 		}
 	}
+
+	// disable admin api check
+	if (getBooleanValue(c.env.DISABLE_ADMIN_PASSWORD_CHECK)) {
+		await next();
+		return;
+	}
+
 	return c.text("Need Admin Password", 401)
 });
 

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -26,6 +26,8 @@ PREFIX = "tmp"
 # PASSWORDS = ["123", "456"]
 # For admin panel
 # ADMIN_PASSWORDS = ["123", "456"]
+# warning: no password or user check for admin portal
+# DISABLE_ADMIN_PASSWORD_CHECK = false
 # ADMIN CONTACT, CAN BE ANY STRING
 # ADMIN_CONTACT = "xx@xx.xxx"
 DEFAULT_DOMAINS = ["xxx.xxx1" , "xxx.xxx2"] # domain name for no role users


### PR DESCRIPTION
### **User description**
#374


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `DISABLE_ADMIN_PASSWORD_CHECK` to the `Bindings` type definition.
- Implemented `DISABLE_ADMIN_PASSWORD_CHECK` in the admin authentication middleware to allow bypassing admin password checks.
- Documented the `DISABLE_ADMIN_PASSWORD_CHECK` configuration option in both English and Chinese CLI documentation.
- Updated the wrangler configuration template to include the `DISABLE_ADMIN_PASSWORD_CHECK` option.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.d.ts</strong><dd><code>Add `DISABLE_ADMIN_PASSWORD_CHECK` to Bindings type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/types.d.ts

- Added `DISABLE_ADMIN_PASSWORD_CHECK` to `Bindings` type.



</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/386/files#diff-583fb024d5c9d1efac71bbea788d8379e5e8fc2f0bb1696a9863c6f6cac54bee">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>worker.ts</strong><dd><code>Implement `DISABLE_ADMIN_PASSWORD_CHECK` in admin middleware</code></dd></summary>
<hr>

worker/src/worker.ts

<li>Added check for <code>DISABLE_ADMIN_PASSWORD_CHECK</code> in admin authentication <br>middleware.<br>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/386/files#diff-c007030a206d7e4e2a4879ba673551e7633ad914b67cfac204096edced3f80a2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>wrangler.toml.template</strong><dd><code>Add `DISABLE_ADMIN_PASSWORD_CHECK` option in wrangler template</code></dd></summary>
<hr>

worker/wrangler.toml.template

- Added `DISABLE_ADMIN_PASSWORD_CHECK` configuration option.



</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/386/files#diff-743273da72481b71fbeb1dddfd294be9249554eef65691dfc9bcfa9f0fd971fb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.md</strong><dd><code>Document `DISABLE_ADMIN_PASSWORD_CHECK` option in CLI documentation</code></dd></summary>
<hr>

vitepress-docs/docs/en/cli.md

- Documented `DISABLE_ADMIN_PASSWORD_CHECK` configuration option.



</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/386/files#diff-3f8f72a691fa19c8581621e91cf67ad28855af7a57e58513f6563cf4c8886e5f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>worker.md</strong><dd><code>Document `DISABLE_ADMIN_PASSWORD_CHECK` option in Chinese CLI guide</code></dd></summary>
<hr>

vitepress-docs/docs/zh/guide/cli/worker.md

<li>Documented <code>DISABLE_ADMIN_PASSWORD_CHECK</code> configuration option in <br>Chinese.<br>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/386/files#diff-f760a2ec5dad4b6bda0bd4a9325274567778add8cb984e73650dbaaf680c9178">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>admin.md</strong><dd><code>Add `DISABLE_ADMIN_PASSWORD_CHECK` section in admin feature guide</code></dd></summary>
<hr>

vitepress-docs/docs/zh/guide/feature/admin.md

<li>Added section about <code>DISABLE_ADMIN_PASSWORD_CHECK</code> in admin feature <br>guide.<br>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/386/files#diff-99dbdc1c9699e92d8f1ece5ea806d153f7fd9337dc5fe5cf17615640cbc90b38">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

