### PR TITLE
fix: UI admin page show modal when no need password

### DIFF
--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n'
 
 import { useGlobalState } from '../store'
@@ -30,6 +30,7 @@ const message = useMessage()
 
 const authFunc = async () => {
   try {
+    adminAuth.value = tmpAdminAuth.value;
     location.reload()
   } catch (error) {
     message.error(error.message || "error");
@@ -85,22 +86,21 @@ const { t } = useI18n({
   }
 });
 
+const showAdminPasswordModal = computed(() => !showAdminPage.value || showAdminAuth.value)
+const tmpAdminAuth = ref('')
+
 onMounted(async () => {
   // make sure user_id is fetched
   if (!userSettings.value.user_id) await api.getUserSettings(message);
-  if (!showAdminPage.value) {
-    showAdminAuth.value = true;
-    return;
-  }
 })
 </script>
 
 <template>
   <div>
-    <n-modal v-model:show="showAdminAuth" :closable="false" :closeOnEsc="false" :maskClosable="false" preset="dialog"
-      :title="t('accessHeader')">
+    <n-modal v-model:show="showAdminPasswordModal" :closable="false" :closeOnEsc="false" :maskClosable="false"
+      preset="dialog" :title="t('accessHeader')">
       <p>{{ t('accessTip') }}</p>
-      <n-input v-model:value="adminAuth" type="textarea" :autosize="{ minRows: 3 }" />
+      <n-input v-model:value="tmpAdminAuth" type="password" show-password-on="click" />
       <template #action>
         <n-button @click="authFunc" type="primary" :loading="loading">
           {{ t('ok') }}

--- a/frontend/src/views/Header.vue
+++ b/frontend/src/views/Header.vue
@@ -260,7 +260,7 @@ onMounted(async () => {
         <n-modal v-model:show="showAuth" :closable="false" :closeOnEsc="false" :maskClosable="false" preset="dialog"
             :title="t('accessHeader')">
             <p>{{ t('accessTip') }}</p>
-            <n-input v-model:value="auth" type="textarea" :autosize="{ minRows: 3 }" />
+            <n-input v-model:value="auth" type="password" show-password-on="click" />
             <template #action>
                 <n-button :loading="loading" @click="authFunc" type="primary">
                     {{ t('ok') }}


### PR DESCRIPTION
### **User description**
#390


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed the issue where the admin page showed a modal unnecessarily when no password was needed.
- Enhanced the admin authentication modal by introducing a computed property `showAdminPasswordModal`.
- Changed the input type to `password` with `show-password-on` attribute in both `Admin.vue` and `Header.vue`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Admin.vue</strong><dd><code>Fix and enhance admin authentication modal behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/Admin.vue

<li>Added <code>computed</code> import from <code>vue</code>.<br> <li> Introduced <code>showAdminPasswordModal</code> computed property.<br> <li> Replaced direct <code>adminAuth</code> binding with <code>tmpAdminAuth</code>.<br> <li> Changed input type to <code>password</code> with <code>show-password-on</code> attribute.<br>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/419/files#diff-78137b072a7fa52c6d503efb9a3d32c07da5073dd5ca32ac48b1402ac2481a55">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Header.vue</strong><dd><code>Update authentication input type in header modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/Header.vue

<li>Changed input type to <code>password</code> with <code>show-password-on</code> attribute.<br>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/419/files#diff-a80b3d70a6be259910c988c05d497228b10a5e686042743c1831584fb391360d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

