### PR TITLE
fix: |UI| admin mails unknown page call wrong api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 <!-- markdownlint-disable-file MD004 MD024 MD034 MD036 -->
 # CHANGE LOG
 
-## main(v0.8.3)
+## main(v0.8.4)
+
+- fix: |UI| 修复 admin portal 无收件人邮箱删除调用api 错误
+
+## v0.8.3
 
 - feat: |Github Action| 增加自动更新并部署功能
 - feat: |UI| admin 用户设置，支持 oauth2 配置的删除

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare_temp_email",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/views/admin/MailsUnknow.vue
+++ b/frontend/src/views/admin/MailsUnknow.vue
@@ -11,7 +11,7 @@ const fetchMailUnknowData = async (limit, offset) => {
 }
 
 const deleteMail = async (curMailId) => {
-    await api.fetch(`/api/mails/${curMailId}`, { method: 'DELETE' });
+    await api.fetch(`/admin/mails/${curMailId}`, { method: 'DELETE' });
 };
 </script>
 

--- a/pages/package.json
+++ b/pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temp-email-pages",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/vitepress-docs/package.json
+++ b/vitepress-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "temp-mail-docs",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare_temp_email",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -1,5 +1,5 @@
 export const CONSTANTS = {
-    VERSION: 'v0.8.3',
+    VERSION: 'v0.8.4',
 
     // DB settings
     ADDRESS_BLOCK_LIST_KEY: 'address_block_list',


### PR DESCRIPTION
### **PR Type**
bug fix


___

### **Description**
- Corrected API endpoint for deleting mails in admin view


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MailsUnknow.vue</strong><dd><code>Correct API endpoint for deleting mails</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/admin/MailsUnknow.vue

<li>Fixed the API endpoint for deleting mails from <code>/api/mails/</code> to <br><code>/admin/mails/</code>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/542/files#diff-3ff95e089e16c427acbb2adee5316571377a0eb1034d6dac9ae312259733d8d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information