### PR TITLE
fix: rpc headers covert & typo

### DIFF
--- a/worker/src/common.ts
+++ b/worker/src/common.ts
@@ -292,13 +292,14 @@ export const commonParseMail = async (parsedEmailContext: ParsedEmailContext): P
     try {
         const { default: PostalMime } = await import('postal-mime');
         const parsedEmail = await PostalMime.parse(raw_mail);
-        return {
+        parsedEmailContext.parsedEmail = {
             sender: parsedEmail.from ? `${parsedEmail.from.name} <${parsedEmail.from.address}>` : "",
             subject: parsedEmail.subject || "",
             text: parsedEmail.text || "",
             html: parsedEmail.html || "",
             headers: parsedEmail.headers || [],
         };
+        return parsedEmailContext.parsedEmail;
     }
     catch (e) {
         console.error("Failed use PostalMime to parse email", e);
@@ -451,9 +452,17 @@ export async function triggerAnotherWorker(
             console.log(`worker.binding = ${bindingName} not match keywords, parsedText = ${parsedText}`);
             continue;
         }
-
         try {
-            const requestBody = JSON.stringify(rpcEmailMessage);
+            const bodyObj = { ...rpcEmailMessage } as any;
+            if (bodyObj.headers && typeof bodyObj.headers.forEach === "function") {
+                const headerObj: any = {}
+                bodyObj.headers.forEach((value: string, key: string) => {
+                    headerObj[key] = value;
+                });
+                bodyObj.headers = headerObj
+            }
+            const requestBody = JSON.stringify(bodyObj);
+            console.log(`exec worker , binding = ${bindingName} , requestBody = ${requestBody}`);
             await method(requestBody);
         } catch (e1) {
             console.error(`execute method = ${methodName} error`, e1);

--- a/worker/src/email/index.ts
+++ b/worker/src/email/index.ts
@@ -80,16 +80,13 @@ async function email(message: ForwardableEmailMessage, env: Bindings, ctx: Execu
 
     // trigger another worker
     try {
-        const headersMap = new Map<string, string>();
-        if (message.headers) {
-            message.headers.forEach((value, key) => { headersMap.set(key, value); });
-        }
-        const parsedText = (await commonParseMail(parsedEmailContext))?.text ?? ""
+        const parsedEmail = (await commonParseMail(parsedEmailContext));
+        const parsedText = parsedEmail?.text ?? ""
         const rpcEmail: RPCEmailMessage = {
             from: message.from,
             to: message.to,
             rawEmail: rawEmail,
-            headers: headersMap
+            headers: message.headers
         }
         await triggerAnotherWorker({ env: env } as Context<HonoCustomType>, rpcEmail, parsedText);
     } catch (error) {

--- a/worker/src/telegram_api/telegram.ts
+++ b/worker/src/telegram_api/telegram.ts
@@ -338,8 +338,8 @@ export async function sendMailToTelegram(
         return;
     }
     const settings = await c.env.KV.get<TelegramSettings>(CONSTANTS.TG_KV_SETTINGS_KEY, "json");
-    const golbalPush = settings?.enableGlobalMailPush && settings?.globalMailPushList;
-    if (!userId && !golbalPush) {
+    const globalPush = settings?.enableGlobalMailPush && settings?.globalMailPushList;
+    if (!userId && !globalPush) {
         return;
     }
     const mailId = await c.env.DB.prepare(
@@ -353,7 +353,7 @@ export async function sendMailToTelegram(
         url.searchParams.set("mail_id", mailId);
         miniAppButtons.push(Markup.button.webApp("查看邮件", url.toString()));
     }
-    if (golbalPush) {
+    if (globalPush) {
         for (const pushId of settings.globalMailPushList) {
             await bot.telegram.sendMessage(pushId, mail, {
                 ...Markup.inlineKeyboard([

--- a/worker/src/types.d.ts
+++ b/worker/src/types.d.ts
@@ -108,7 +108,7 @@ type RPCEmailMessage = {
     from: string | undefined | null,
     to: string | undefined | null,
     rawEmail: string | undefined | null,
-    headers: Map<string, string>,
+    headers: object | undefined | null,
 }
 
 type ParsedEmailContext = {


### PR DESCRIPTION
- parsedEmailContext在commonParseMail解析后设置了parsedEmail（否则仍然会重复解析）
- 请求头使用objectc传递（用 Map<string,string> 及 Header类，在JSON.stringify后会是{}）
- 修改telegram.ts中的typo

--------------------

不使用parsedEmail中的headers主要是解析后和原样不一致，例如Message-ID，原本<xxx>，解析后parsedEmail变成xxx，无法保持原数据