### PR TITLE
fix: telegram mail page use iframe show email

### DIFF
--- a/frontend/src/views/telegram/Mail.vue
+++ b/frontend/src/views/telegram/Mail.vue
@@ -59,7 +59,8 @@ onMounted(async () => {
             <n-tag v-if="showEMailTo" type="info">
                 TO: {{ curMail.address }}
             </n-tag>
-            <div v-html="curMail.message" style="margin-top: 10px;"></div>
+            <iframe :srcdoc="curMail.message" style="margin-top: 10px;width: 100%; height: 100%;">
+            </iframe>
         </n-card>
     </div>
 </template>


### PR DESCRIPTION
### **PR Type**
bug fix, enhancement


___

### **Description**
- Replace `div` with `iframe` to display email content.

- Improve email rendering in Telegram mail page.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Mail.vue</strong><dd><code>Use iframe for email content rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/telegram/Mail.vue

<li>Replace <code>div</code> with <code>iframe</code> for email content.<br> <li> Adjust iframe dimensions for better display.


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/561/files#diff-0b8768ec002961fa240a6c2f0ee66bf1f1bddaaa4f85c179cda3985344f5dbd1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information