### PR TITLE
[Feature] 基于子域名转发到不同的邮箱中去 #645

### DIFF
--- a/worker/src/admin_api/worker_config.ts
+++ b/worker/src/admin_api/worker_config.ts
@@ -1,7 +1,7 @@
 import { Context } from 'hono';
 
 import { HonoCustomType } from '../types';
-import { getAdminPasswords, getBooleanValue, getDefaultDomains, getDomains, getIntValue, getPasswords, getStringArray, getStringValue, getUserRoles, getAnotherWorkerList, getSplitStringListValue } from '../utils';
+import { getAdminPasswords, getBooleanValue, getDefaultDomains, getDomains, getIntValue, getPasswords, getStringArray, getStringValue, getUserRoles, getForwardAddressList, getAnotherWorkerList, getSplitStringListValue } from '../utils';
 import { CONSTANTS } from '../constants';
 import { isS3Enabled } from '../mails_api/s3_attachment';
 
@@ -20,7 +20,7 @@ export default {
             "MIN_ADDRESS_LEN": getIntValue(c.env.MIN_ADDRESS_LEN, 1),
             "MAX_ADDRESS_LEN": getIntValue(c.env.MAX_ADDRESS_LEN, 30),
 
-            "FORWARD_ADDRESS_LIST": getStringArray(c.env.FORWARD_ADDRESS_LIST),
+            "FORWARD_ADDRESS_LIST": getForwardAddressList(c),
             "DEFAULT_DOMAINS": getDefaultDomains(c),
             "DOMAINS": getDomains(c),
             "DOMAIN_LABELS": getStringArray(c.env.DOMAIN_LABELS),

--- a/worker/src/types.d.ts
+++ b/worker/src/types.d.ts
@@ -4,6 +4,11 @@ export type UserRole = {
     prefix: string | undefined | null
 }
 
+export type ForwardAddressList = {
+    domains: string[] | undefined | null,
+    forward: string
+}
+
 export type Bindings = {
     // bindings
     DB: D1Database
@@ -43,7 +48,7 @@ export type Bindings = {
     ADMIN_CONTACT: string | undefined
     COPYRIGHT: string | undefined
     DISABLE_SHOW_GITHUB: string | boolean | undefined
-    FORWARD_ADDRESS_LIST: string | string[] | undefined
+    FORWARD_ADDRESS_LIST: string | ForwardAddressList[] | undefined
 
     ENABLE_CHECK_JUNK_MAIL: string | boolean | undefined
     JUNK_MAIL_CHECK_LIST: string | string[] | undefined

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -1,6 +1,6 @@
 import { Context } from "hono";
 import { createMimeMessage } from "mimetext";
-import { HonoCustomType, UserRole, AnotherWorker } from "./types";
+import { HonoCustomType, UserRole, AnotherWorker, ForwardAddressList } from "./types";
 
 export const getJsonObjectValue = <T = any>(
     value: string | any
@@ -163,6 +163,22 @@ export const getUserRoles = (c: Context<HonoCustomType>): UserRole[] => {
         }
     }
     return c.env.USER_ROLES;
+}
+
+export const getForwardAddressList = (c: Context<HonoCustomType>): ForwardAddressList[] => {
+    if (!c.env.FORWARD_ADDRESS_LIST) {
+        return [];
+    }
+    // check if FORWARD_ADDRESS_LIST is an array, if not use json.parse
+    if (!Array.isArray(c.env.FORWARD_ADDRESS_LIST)) {
+        try {
+            return JSON.parse(c.env.FORWARD_ADDRESS_LIST);
+        } catch (e) {
+            console.error("Failed to parse FORWARD_ADDRESS_LIST", e);
+            return [];
+        }
+    }
+    return c.env.FORWARD_ADDRESS_LIST;
 }
 
 export const getAnotherWorkerList = (c: Context<HonoCustomType>): AnotherWorker[] => {

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -79,7 +79,7 @@ ENABLE_AUTO_REPLY = false
 # telegram bot info, predefined bot info can reduce latency of the webhook
 # TG_BOT_INFO = "{}"
 # global forward address list, if set, all emails will be forwarded to these addresses
-# FORWARD_ADDRESS_LIST = ["xxx@xxx.com"]
+# FORWARD_ADDRESS_LIST = [{"domains":[""],"forward":"xxx1@xxx.com",},{"domains":["subdomain-1.domain.com","subdomain-2.domain.com"],"forward":"xxx2@xxx.com"}]
 # Frontend URL
 # FRONTEND_URL = "https://xxxx.xxx"
 # Enable check junk mail


### PR DESCRIPTION
[Feature] 基于子域名转发到不同的邮箱中去 #645
按我自己的理解，进行了源码修改，主要改造了 `FORWARD_ADDRESS_LIST` 变量，使其同 `USER_ROLES` 变量语法类似。
`FORWARD_ADDRESS_LIST` 变量值格式为： `[{"domains":[""],"forward":"xxx1@xxx.com",},{"domains":["subdomain-1.domain.com","subdomain-2.domain.com"],"forward":"xxx2@xxx.com"}]` 。其中domains的列表值可为空，为空则代表将全局所有邮件转发到指定邮箱。