### PR TITLE
feat(oauth2): add default role assignment for new OAuth2 users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## main(v1.0.1)
 
 - feat: |UI| 增加极简模式主页, 可在 `外观` 中切换
+- fix: 修复 oauth2 登录时，default role 不生效的问题
 
 ## v1.0.0
 


### PR DESCRIPTION
### **User description**
- Add default role assignment logic in OAuth2 login flow
- Import getStringValue and getUserRoles utilities
- Validate default role exists in system before assignment
- Use ON CONFLICT DO NOTHING to preserve existing user roles
- Add proper error handling for role assignment failures

#687


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Assign default roles to new OAuth2 users during registration.

- Validate the existence of the default role before assignment.

- Prevent duplicate role assignments using `ON CONFLICT DO NOTHING`.

- Improve error handling for role assignment failures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oauth2.ts</strong><dd><code>Implement default role assignment in OAuth2 flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/user_api/oauth2.ts

<li>Added logic to assign default roles during OAuth2 user registration.<br> <li> Validated the existence of the default role in the system.<br> <li> Used <code>ON CONFLICT DO NOTHING</code> to avoid duplicate role entries.<br> <li> Enhanced error handling for role assignment and database operations.


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/688/files#diff-fede9bc68112c797eefa07c6e6cc20a6aa107addb3e5636757131589a435e13b">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>