### PR TITLE
fix: require explicit 'true' value for debug mode in deployment

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -60,7 +60,7 @@ jobs:
             echo "Applied mail-parser-wasm-worker patch"
           fi
 
-          if [ -n "$debug_mode" ]; then
+          if [ "$debug_mode" = "true" ]; then
             pnpm run deploy
           else
             output=$(pnpm run deploy 2>&1)


### PR DESCRIPTION
- Update GitHub Actions workflow to only enable debug mode when DEBUG_MODE secret is exactly 'true'
- Previously debug mode was enabled for any non-empty value, which could lead to accidental activation
- Change from `[ -n "$debug_mode" ]` to `[ "$debug_mode" = "true" ]` for precise control

🤖 Generated with [Claude Code](https://claude.ai/code)

#732 