### PR TITLE
feat: add role-based address limit configuration

### DIFF
--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -14,6 +14,7 @@ import AccountSettings from './admin/AccountSettings.vue';
 import UserManagement from './admin/UserManagement.vue';
 import UserSettings from './admin/UserSettings.vue';
 import UserOauth2Settings from './admin/UserOauth2Settings.vue';
+import RoleAddressConfig from './admin/RoleAddressConfig.vue';
 import Mails from './admin/Mails.vue';
 import MailsUnknow from './admin/MailsUnknow.vue';
 import About from './common/About.vue';
@@ -61,6 +62,7 @@ const { t } = useI18n({
       user_management: 'User Management',
       user_settings: 'User Settings',
       userOauth2Settings: 'Oauth2 Settings',
+      roleAddressConfig: 'Role Address Config',
       unknow: 'Mails with unknow receiver',
       senderAccess: 'Sender Access Control',
       sendBox: 'Send Box',
@@ -88,6 +90,7 @@ const { t } = useI18n({
       user_management: '用户管理',
       user_settings: '用户设置',
       userOauth2Settings: 'Oauth2 设置',
+      roleAddressConfig: '角色地址配置',
       unknow: '无收件人邮件',
       senderAccess: '发件权限控制',
       sendBox: '发件箱',
@@ -172,6 +175,9 @@ onMounted(async () => {
           </n-tab-pane>
           <n-tab-pane name="userOauth2Settings" :tab="t('userOauth2Settings')">
             <UserOauth2Settings />
+          </n-tab-pane>
+          <n-tab-pane name="roleAddressConfig" :tab="t('roleAddressConfig')">
+            <RoleAddressConfig />
           </n-tab-pane>
         </n-tabs>
       </n-tab-pane>

--- a/frontend/src/views/admin/RoleAddressConfig.vue
+++ b/frontend/src/views/admin/RoleAddressConfig.vue
@@ -1,0 +1,153 @@
+<script setup>
+import { ref, onMounted, h } from 'vue';
+import { useI18n } from 'vue-i18n'
+import { NInputNumber, NTag, NSpace, NButton } from 'naive-ui';
+
+import { useGlobalState } from '../../store'
+import { api } from '../../api'
+
+const { loading } = useGlobalState()
+const message = useMessage()
+
+const { t } = useI18n({
+    messages: {
+        en: {
+            role: 'Role',
+            maxAddressCount: 'Max Address Count',
+            save: 'Save',
+            successTip: 'Success',
+            noRolesAvailable: 'No roles available in system config',
+            roleConfigDesc: 'Configure maximum address count for each user role. Role-based limits take priority over global settings.',
+            notConfigured: 'Not Configured (Use Global Settings)',
+        },
+        zh: {
+            role: '角色',
+            maxAddressCount: '最大地址数量',
+            save: '保存',
+            successTip: '成功',
+            noRolesAvailable: '系统配置中没有可用的角色',
+            roleConfigDesc: '为每个用户角色配置最大地址数量。角色配置优先于全局设置。',
+            notConfigured: '未配置（使用全局设置）',
+        }
+    }
+});
+
+const systemRoles = ref([])
+const tableData = ref([])
+
+const fetchUserRoles = async () => {
+    try {
+        const results = await api.fetch(`/admin/user_roles`);
+        systemRoles.value = results;
+    } catch (error) {
+        console.log(error)
+        message.error(error.message || "error");
+    }
+}
+
+const fetchRoleConfigs = async () => {
+    try {
+        const { configs } = await api.fetch(`/admin/role_address_config`);
+        tableData.value = systemRoles.value.map(roleObj => ({
+            role: roleObj.role,
+            max_address_count: configs[roleObj.role]?.maxAddressCount ?? null,
+        }));
+    } catch (error) {
+        console.log(error)
+        message.error(error.message || "error");
+    }
+}
+
+const saveConfig = async () => {
+    try {
+        // convert tableData to object with nested structure
+        const configs = {};
+        tableData.value.forEach(row => {
+            if (row.max_address_count !== null && row.max_address_count !== undefined) {
+                configs[row.role] = { maxAddressCount: row.max_address_count };
+            }
+        });
+
+        await api.fetch(`/admin/role_address_config`, {
+            method: 'POST',
+            body: JSON.stringify({ configs })
+        });
+        message.success(t('successTip'));
+        await fetchRoleConfigs();
+    } catch (error) {
+        console.log(error)
+        message.error(error.message || "error");
+    }
+}
+
+const columns = [
+    {
+        title: t('role'),
+        key: 'role',
+        width: 200,
+        render(row) {
+            return h(NTag, {
+                type: 'info',
+                bordered: false
+            }, {
+                default: () => row.role
+            })
+        }
+    },
+    {
+        title: t('maxAddressCount'),
+        key: 'max_address_count',
+        render(row) {
+            return h(NInputNumber, {
+                value: row.max_address_count,
+                min: 0,
+                max: 999,
+                clearable: true,
+                placeholder: t('notConfigured'),
+                style: 'width: 200px;',
+                onUpdateValue: (value) => {
+                    row.max_address_count = value;
+                }
+            })
+        }
+    }
+]
+
+onMounted(async () => {
+    await fetchUserRoles();
+    await fetchRoleConfigs();
+})
+</script>
+
+<template>
+    <div style="margin-top: 10px;">
+        <n-alert type="info" :bordered="false" style="margin-bottom: 20px;">
+            {{ t('roleConfigDesc') }}
+        </n-alert>
+
+        <n-alert v-if="systemRoles.length === 0" type="warning" :bordered="false">
+            {{ t('noRolesAvailable') }}
+        </n-alert>
+
+        <div v-else>
+            <n-space justify="end" style="margin-bottom: 12px;">
+                <n-button :loading="loading" @click="saveConfig" type="primary">
+                    {{ t('save') }}
+                </n-button>
+            </n-space>
+
+            <n-data-table
+                :columns="columns"
+                :data="tableData"
+                :bordered="false"
+                embedded
+            />
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.n-data-table {
+    min-width: 600px;
+}
+</style>

--- a/worker/src/admin_api/admin_user_api.ts
+++ b/worker/src/admin_api/admin_user_api.ts
@@ -2,7 +2,7 @@ import { Context } from 'hono';
 
 import { CONSTANTS } from '../constants';
 import { getJsonSetting, saveSetting, checkUserPassword, getDomains, getUserRoles } from '../utils';
-import { UserSettings, GeoData, UserInfo } from "../models";
+import { UserSettings, GeoData, UserInfo, RoleAddressConfig } from "../models";
 import { handleListQuery } from '../common'
 import UserBindAddressModule from '../user_api/bind_address';
 import i18n from '../i18n';
@@ -165,5 +165,15 @@ export default {
         return c.json({
             results: results,
         });
+    },
+    getRoleAddressConfig: async (c: Context<HonoCustomType>) => {
+        const value = await getJsonSetting<RoleAddressConfig>(c, CONSTANTS.ROLE_ADDRESS_CONFIG_KEY);
+        const configs = value || {};
+        return c.json({ configs });
+    },
+    saveRoleAddressConfig: async (c: Context<HonoCustomType>) => {
+        const { configs } = await c.req.json<{ configs: RoleAddressConfig }>();
+        await saveSetting(c, CONSTANTS.ROLE_ADDRESS_CONFIG_KEY, JSON.stringify(configs));
+        return c.json({ success: true });
     },
 }

--- a/worker/src/admin_api/index.ts
+++ b/worker/src/admin_api/index.ts
@@ -344,6 +344,8 @@ api.post('/admin/users', admin_user_api.createUser)
 api.post('/admin/users/:user_id/reset_password', admin_user_api.resetPassword)
 api.get('/admin/user_roles', async (c) => c.json(getUserRoles(c)))
 api.post('/admin/user_roles', admin_user_api.updateUserRoles)
+api.get('/admin/role_address_config', admin_user_api.getRoleAddressConfig)
+api.post('/admin/role_address_config', admin_user_api.saveRoleAddressConfig)
 api.get('/admin/users/bind_address/:user_id', admin_user_api.getBindedAddresses)
 api.post('/admin/users/bind_address', admin_user_api.bindAddress)
 

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -14,6 +14,7 @@ export const CONSTANTS = {
     VERIFIED_ADDRESS_LIST_KEY: 'verified_address_list',
     NO_LIMIT_SEND_ADDRESS_LIST_KEY: 'no_limit_send_address_list',
     EMAIL_RULE_SETTINGS_KEY: 'email_rule_settings',
+    ROLE_ADDRESS_CONFIG_KEY: 'role_address_config',
 
     // KV
     TG_KV_PREFIX: "temp-mail-telegram",

--- a/worker/src/models/index.ts
+++ b/worker/src/models/index.ts
@@ -154,3 +154,10 @@ export type EmailRuleSettings = {
     blockReceiveUnknowAddressEmail: boolean;
     emailForwardingList: SubdomainForwardAddressList[]
 }
+
+export type RoleConfig = {
+    maxAddressCount?: number;
+    // future configs can be added here
+}
+
+export type RoleAddressConfig = Record<string, RoleConfig>;


### PR DESCRIPTION
### **User description**
#738

- Add RoleAddressConfig component in admin panel
- Implement role_address_config API endpoints (GET/POST)
- Add getMaxAddressCount function with validation chain
- Priority: role config > global settings
- Support editable table with clearable input
- Add extensible RoleConfig type for future fields
- Use context for current user, query DB for target user
- Optimize state management (remove redundant roleConfigsMap)

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced role-based email address limits in the admin panel.

- Added `RoleAddressConfig` component for managing role-specific limits.

- Implemented backend API endpoints for fetching and saving configurations.

- Enhanced validation logic for address binding with role-based limits.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>Admin.vue</strong><dd><code>Added `RoleAddressConfig` tab in the admin panel.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-78137b072a7fa52c6d503efb9a3d32c07da5073dd5ca32ac48b1402ac2481a55">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RoleAddressConfig.vue</strong><dd><code>New component for managing role-based address limits.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-222ed82c54da3fdffcf5abb4dfbaa3e7196ea4786c473eebe2b002926c5aae5d">+153/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>admin_user_api.ts</strong><dd><code>Added API methods for role-based address configuration.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-2843fd3d54aa9aa8054d2530e84a06de3068c31fd5c7d5246db5d2a4234a6196">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Defined `RoleConfig` and `RoleAddressConfig` types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-430bcc4ffa98738e7419c774a53ba2ce8b5127a36b3741e89bf36b95a56f02bc">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Registered new API routes for role-based configurations.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-b470c4c47ce4a700cd8aac644d07d8a747d439bb6d69e9392a198b3a931fe2e7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>constants.ts</strong><dd><code>Added constant for role address configuration key.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-cab08ba19c1499ed426fc4918a5613e22eb95c3427c7467ce330f5ee0d69d01e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>bind_address.ts</strong><dd><code>Enhanced address binding logic with role-based limits.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/741/files#diff-ada3e8ad268246f0c99c97065551303c02fded466c73a4f525f6206cb49bdebf">+29/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>