### PR TITLE
fix: 修复自定义认证密码功能并更新版本号

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 <!-- markdownlint-disable-file MD004 MD024 MD034 MD036 -->
 # CHANGE LOG
 
-## v1.1.1(feature/email)
-
-- fix: 修复自定义认证密码功能异常的问题 (前端属性名错误 & /open_api 接口被拦截)
-
 ## v1.1.0(main)
 
 - feat: |Admin| 维护页面增加清理 n 天前空邮件的邮箱地址功能
+- fix: 修复自定义认证密码功能异常的问题 (前端属性名错误 & /open_api 接口被拦截)
 
 ## v1.0.7
 

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -1,5 +1,5 @@
 export const CONSTANTS = {
-    VERSION: 'v' + '1.0.7',
+    VERSION: 'v' + '1.1.0',
 
     // DB Version
     DB_VERSION_KEY: 'db_version',


### PR DESCRIPTION
## Summary

- 修复前端属性名错误 (openSettings.auth -> openSettings.needAuth)
- 修复 /open_api/settings 接口被自定义认证拦截的问题
- 更新版本号到 v1.1.0
- 整理 CHANGELOG

## Test plan

- [ ] 验证自定义认证密码功能正常工作
- [ ] 测试 /open_api/settings 接口可以正常访问

🤖 Generated with [Claude Code](https://claude.ai/code)