### PR TITLE
fix: display auth_code result directly without result_text

### DIFF
--- a/frontend/src/components/AiExtractInfo.vue
+++ b/frontend/src/components/AiExtractInfo.vue
@@ -82,6 +82,11 @@ const isLink = computed(() => {
 
 const displayText = computed(() => {
   if (!aiExtract.value) return '';
+  // For auth_code, always show the raw result (verification code)
+  if (aiExtract.value.type === 'auth_code') {
+    return aiExtract.value.result;
+  }
+  // For links, prefer result_text as display label
   return aiExtract.value.result_text || aiExtract.value.result;
 });
 


### PR DESCRIPTION
### **User description**
## Summary
Fix AiExtractInfo component to display verification codes (auth_code) using the raw `result` value instead of `result_text`.

## Problem
The `displayText` computed property was using `result_text || result` for all types, which could potentially show unwanted text for verification codes instead of the actual code.

## Solution
Modified the `displayText` logic to:
- **Verification codes** (`auth_code`): Always return `result` (the actual code like "123456")
- **Links** (all other types): Continue to prefer `result_text` as display label, fallback to `result` (URL)

## Changes
- Updated `displayText` computed property in `frontend/src/components/AiExtractInfo.vue`
- Added explicit type checking for `auth_code`
- Added inline comments for clarity

## Code
\`\`\`typescript
const displayText = computed(() => {
  if (!aiExtract.value) return '';
  // For auth_code, always show the raw result (verification code)
  if (aiExtract.value.type === 'auth_code') {
    return aiExtract.value.result;
  }
  // For links, prefer result_text as display label
  return aiExtract.value.result_text || aiExtract.value.result;
});
\`\`\`

## Testing
- [x] Verification codes display correctly in compact mode
- [x] Verification codes display correctly in full mode (line 115 already uses `aiExtract.result`)
- [x] Links continue to display `result_text` when available

## Impact
- ✅ No breaking changes
- ✅ Improves user experience for verification code display
- ✅ Maintains existing behavior for link types

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed `displayText` logic to correctly display `auth_code` values.

- Added explicit type checking for `auth_code` in `AiExtractInfo.vue`.

- Improved user experience for verification code display.

- Maintained existing behavior for link types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AiExtractInfo.vue</strong><dd><code>Adjusted `displayText` logic for `auth_code` and links</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/AiExtractInfo.vue

<li>Updated <code>displayText</code> logic for <code>auth_code</code> type.<br> <li> Added comments to clarify the new logic.<br> <li> Ensured fallback behavior for link types remains intact.


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/777/files#diff-8645f8c6fffbf82f110d38ca462cc3875c0addb80816110704d70c9fd3400523">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>