### PR TITLE
fix: exclude telegram routes from x-custom-auth check

### DIFF
--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -52,7 +52,7 @@ app.use('/*', async (c, next) => {
 
 	// check header x-custom-auth
 	const passwords = getPasswords(c);
-	if (!c.req.path.startsWith("/open_api") && passwords && passwords.length > 0) {
+	if (!c.req.path.startsWith("/open_api") && !c.req.path.startsWith("/telegram/") && passwords && passwords.length > 0) {
 		const auth = c.req.raw.headers.get("x-custom-auth");
 		if (!auth || !passwords.includes(auth)) {
 			return c.text(msgs.CustomAuthPasswordMsg, 401)


### PR DESCRIPTION
### **User description**
## Summary
- Exclude `/telegram/` routes from `x-custom-auth` header check
- Telegram webhook and API calls can now function without custom auth password
- Telegram API has its own authentication via bot tokens

## Test plan
- [ ] Verify telegram webhook still works when `PASSWORDS` is configured
- [ ] Verify other routes still require `x-custom-auth` when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude `/telegram/` routes from `x-custom-auth` header check.

- Ensure Telegram API calls function without custom auth.

- Maintain authentication for other routes with `x-custom-auth`.

- Simplify integration for Telegram webhook and bot token authentication.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.ts</strong><dd><code>Exclude `/telegram/` routes from custom auth check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/worker.ts

<li>Added condition to exclude <code>/telegram/</code> routes from <code>x-custom-auth</code> check.<br> <li> Ensured other routes still validate <code>x-custom-auth</code> when required.


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/780/files#diff-c007030a206d7e4e2a4879ba673551e7633ad914b67cfac204096edced3f80a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>