### PR TITLE
fix: escape @ symbol in vue-i18n to fix SyntaxError

### DIFF
--- a/frontend/src/views/admin/Maintenance.vue
+++ b/frontend/src/views/admin/Maintenance.vue
@@ -50,7 +50,7 @@ const { t } = useI18n({
             sqlName: "Name",
             sqlStatement: "SQL Statement (DELETE only)",
             sqlNamePlaceholder: "e.g. Clean old logs",
-            sqlPlaceholder: "e.g. DELETE FROM raw_mails WHERE source GLOB '*@example.com' AND created_at < datetime('now', '-3 day')",
+            sqlPlaceholder: "e.g. DELETE FROM raw_mails WHERE source GLOB '*{'@'}example.com' AND created_at < datetime('now', '-3 day')",
             deleteCustomSql: "Delete",
         },
         zh: {
@@ -75,7 +75,7 @@ const { t } = useI18n({
             sqlName: "名称",
             sqlStatement: "SQL 语句 (仅限 DELETE)",
             sqlNamePlaceholder: "例如: 清理旧日志",
-            sqlPlaceholder: "例如: DELETE FROM raw_mails WHERE source GLOB '*@example.com' AND created_at < datetime('now', '-3 day')",
+            sqlPlaceholder: "例如: DELETE FROM raw_mails WHERE source GLOB '*{'@'}example.com' AND created_at < datetime('now', '-3 day')",
             deleteCustomSql: "删除",
         }
     }


### PR DESCRIPTION
### **User description**
## Summary
- Fix SyntaxError when clicking "Add Custom SQL" button in Maintenance page
- The `@` symbol in i18n translation strings was being interpreted as vue-i18n linked message syntax
- Use `{'@'}` to escape the `@` character in placeholder text

## Test plan
- [ ] Navigate to Admin > Maintenance page
- [ ] Click "Add Custom SQL" button
- [ ] Verify no SyntaxError occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed SyntaxError caused by `@` symbol in vue-i18n.

- Escaped `@` symbol using `{'@'}` in placeholder text.

- Updated placeholder text in both English and Chinese translations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Maintenance.vue</strong><dd><code>Escape `@` symbol in vue-i18n placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/admin/Maintenance.vue

<li>Escaped <code>@</code> symbol in English placeholder text.<br> <li> Escaped <code>@</code> symbol in Chinese placeholder text.<br> <li> Updated <code>sqlPlaceholder</code> key in both translations.


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/783/files#diff-68808e9c7bcf8b34a2d45265cca130c547b77e75a97350ea7d16682e69922ae4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>