### PR TITLE
Add keep_vars option to wrangler.toml.template

### DIFF
--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -2,6 +2,7 @@ name = "cloudflare_temp_email"
 main = "src/worker.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = [ "nodejs_compat" ]
+keep_vars = true
 # if you want use custom_domain, you need to add routes
 # routes = [
 # 	{ pattern = "temp-email-api.xxxxx.xyz", custom_domain = true },


### PR DESCRIPTION
This allows users to easily configure variables on the web interface without them being overwritten.