### PR TITLE
style: use softer blue for AI extraction info in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - fix: |定时任务| 修复定时任务清理报错 `e.get is not a function`，使用可选链安全访问 Context 方法
 
+### Improvements
+
+- style: |AI 提取| 暗色模式下 AI 提取信息使用更柔和的蓝色 (#A8C7FA)，减少视觉疲劳
+
 ## v1.2.0
 
 ### Breaking Changes

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -6,7 +6,17 @@
   <a href="CHANGELOG_EN.md">🇺🇸 English</a>
 </p>
 
-## v1.2.0(main)
+## v1.2.1(main)
+
+### Bug Fixes
+
+- fix: |Scheduled Tasks| Fix scheduled task cleanup error `e.get is not a function`, use optional chaining for safe access to Context methods
+
+### Improvements
+
+- style: |AI Extraction| Use softer blue color (#A8C7FA) for AI extraction info in dark mode to reduce eye strain
+
+## v1.2.0
 
 ### Breaking Changes
 

--- a/frontend/src/components/AiExtractInfo.vue
+++ b/frontend/src/components/AiExtractInfo.vue
@@ -3,8 +3,34 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ContentCopyOutlined, LinkRound, CodeRound } from '@vicons/material';
 import { useMessage } from 'naive-ui';
+import { useGlobalState } from '../store';
 
 const message = useMessage();
+const { isDark } = useGlobalState();
+
+// Dark mode: use Gmail's softer blue (#A8C7FA) for better readability
+const alertThemeOverrides = computed(() => {
+  if (isDark.value) {
+    return {
+      colorSuccess: 'rgba(168, 199, 250, 0.15)',
+      borderSuccess: '1px solid rgba(168, 199, 250, 0.3)',
+      iconColorSuccess: '#A8C7FA',
+      titleTextColorSuccess: '#A8C7FA',
+    }
+  }
+  return {}
+});
+
+const tagThemeOverrides = computed(() => {
+  if (isDark.value) {
+    return {
+      colorSuccess: 'rgba(168, 199, 250, 0.15)',
+      borderSuccess: '1px solid rgba(168, 199, 250, 0.3)',
+      textColorSuccess: '#A8C7FA',
+    }
+  }
+  return {}
+});
 
 const { t } = useI18n({
   messages: {
@@ -108,7 +134,7 @@ const openLink = () => {
 
 <template>
   <div v-if="aiExtract && aiExtract.result" class="ai-extract-info">
-    <n-alert v-if="!compact" type="success" closable>
+    <n-alert v-if="!compact" type="success" closable :theme-overrides="alertThemeOverrides">
       <template #icon>
         <n-icon :component="typeIcon" />
       </template>
@@ -132,7 +158,7 @@ const openLink = () => {
         </n-button>
       </n-space>
     </n-alert>
-    <n-tag v-else type="success" @click="copyToClipboard" style="cursor: pointer;" size="small">
+    <n-tag v-else type="success" @click="copyToClipboard" style="cursor: pointer;" size="small" :theme-overrides="tagThemeOverrides">
       <template #icon>
         <n-icon :component="typeIcon" />
       </template>


### PR DESCRIPTION
### **User description**
## Summary
- Use Gmail's softer blue (#A8C7FA) for AI extraction alert and tag in dark mode to reduce eye strain
- Update CHANGELOG.md and CHANGELOG_EN.md for v1.2.1

## Test plan
- [ ] Toggle dark mode and verify AI extraction info displays with softer blue color
- [ ] Verify light mode remains unchanged (uses default green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced softer blue color for AI extraction info in dark mode.

- Added theme overrides for alerts and tags in dark mode.

- Updated changelogs to document the new style improvement.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DarkMode["Dark Mode Detection"] -- "Triggers" --> ThemeOverrides["Theme Overrides for Alerts and Tags"]
  ThemeOverrides -- "Applies" --> SofterBlue["Softer Blue Color (#A8C7FA)"]
  SofterBlue -- "Documented in" --> Changelogs["CHANGELOG.md & CHANGELOG_EN.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AiExtractInfo.vue</strong><dd><code>Added theme overrides for dark mode styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/AiExtractInfo.vue

<ul><li>Added computed properties for theme overrides in dark mode.<br> <li> Applied softer blue color for alerts and tags in dark mode.<br> <li> Updated alert and tag components to use theme overrides.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/817/files#diff-8645f8c6fffbf82f110d38ca462cc3875c0addb80816110704d70c9fd3400523">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog for dark mode style improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documented the use of softer blue color for AI extraction info in dark <br>mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/817/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Updated English changelog for dark mode style improvement</code></dd></summary>
<hr>

CHANGELOG_EN.md

<ul><li>Documented the use of softer blue color for AI extraction info in dark <br>mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/817/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

