### PR TITLE
docs: add Windows .env file note for VITE_IS_TELEGRAM

### DIFF
--- a/vitepress-docs/docs/en/guide/feature/telegram.md
+++ b/vitepress-docs/docs/en/guide/feature/telegram.md
@@ -76,9 +76,17 @@ For other steps, refer to `Frontend and Backend Separation Deployment` in [UI De
 cd frontend
 pnpm install
 cp .env.example .env.prod
+# Edit .env.prod and set VITE_IS_TELEGRAM=true
 # --project-name can create a separate pages for mini app, you can also share one pages, but may encounter js loading issues
 pnpm run deploy:telegram --project-name=<your_project_name>
 ```
+
+> [!WARNING]
+> Windows users: The inline `VITE_IS_TELEGRAM=true` environment variable in npm scripts does not work on Windows.
+> Please set `VITE_IS_TELEGRAM=true` in your `.env.prod` file manually, then use the regular build command instead:
+> ```bash
+> pnpm run build
+> ```
 
 - After deployment, please fill in the web URL in the `Settings` -> `Telegram Mini App` page `Telegram Mini App URL` in the admin backend.
 - Please execute `/setmenubutton` in `@BotFather`, then enter your web address to set the `Open App` button in the lower left corner.

--- a/vitepress-docs/docs/zh/guide/feature/telegram.md
+++ b/vitepress-docs/docs/zh/guide/feature/telegram.md
@@ -76,9 +76,17 @@ Telegram Bot 支持中英文切换，用户可以通过 `/lang` 命令设置语�
 cd frontend
 pnpm install
 cp .env.example .env.prod
+# 修改 .env.prod 文件，设置 VITE_IS_TELEGRAM=true
 # --project-name 可以单独为 mini app 创建一个 pages, 你也可以公用一个 pages，但是可能遇到 js 加载不了的问题
 pnpm run deploy:telegram --project-name=<你的项目名称>
 ```
+
+> [!WARNING]
+> Windows 用户请注意：`npm scripts` 中的 `VITE_IS_TELEGRAM=true` 内联环境变量写法在 Windows 上不生效。
+> 请在 `.env.prod` 文件中手动设置 `VITE_IS_TELEGRAM=true`，然后使用普通的 build 命令代替：
+> ```bash
+> pnpm run build
+> ```
 
 - 部署完成后，请在 admin 后台的 `设置` -> `电报小程序` 页面 `电报小程序 URL` 中填写网页 URL。
 - 请在 `@BotFather` 处执行 `/setmenubutton`，然后输入你的网页地址，设置左下角的 `Open App` 按钮。


### PR DESCRIPTION
Windows 不支持 npm scripts 中的内联环境变量写法 (VITE_IS_TELEGRAM=true vite build ...)，文档中补充说明 Windows 用户需要在 .env.prod 文件中手动设置 VITE_IS_TELEGRAM=true。

- 中英文文档均已更新
- 增加 WARNING 提示块说明 Windows 兼容方案