### PR TITLE
docs: improve SEO and redirect root to /zh/

### DIFF
--- a/vitepress-docs/docs/.vitepress/config.ts
+++ b/vitepress-docs/docs/.vitepress/config.ts
@@ -4,6 +4,7 @@ import { en } from './en'
 
 export default defineConfig({
   title: "Temp Mail Doc",
+  description: 'CloudFlare 免费收发临时域名邮箱 | Free temporary domain email on CloudFlare',
   lang: 'zh-CN',
   lastUpdated: true,
   locales: {
@@ -13,12 +14,22 @@ export default defineConfig({
   head: [
     ['link', { rel: 'icon', type: 'image/png', href: '/logo.png' }],
     ['meta', { name: 'theme-color', content: '#5f67ee' }],
+    ['meta', { name: 'robots', content: 'index, follow' }],
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:locale', content: 'Temp Mail Doc' }],
-    ['meta', { property: 'og:title', content: 'Temp Mail Doc' }],
+    ['meta', { property: 'og:locale', content: 'zh_CN' }],
+    ['meta', { property: 'og:locale:alternate', content: 'en_US' }],
+    ['meta', { property: 'og:title', content: 'Temp Mail - CloudFlare 临时邮箱' }],
+    ['meta', { property: 'og:description', content: 'CloudFlare 免费收发临时域名邮箱，支持多域名、附件、Telegram Bot、Webhook、SMTP/IMAP' }],
     ['meta', { property: 'og:site_name', content: 'Temp Mail' }],
     ['meta', { property: 'og:image', content: 'https://temp-mail-docs.awsl.uk/logo.png' }],
     ['meta', { property: 'og:url', content: 'https://temp-mail-docs.awsl.uk' }],
+    ['meta', { name: 'twitter:card', content: 'summary' }],
+    ['meta', { name: 'twitter:title', content: 'Temp Mail - CloudFlare 临时邮箱' }],
+    ['meta', { name: 'twitter:description', content: 'CloudFlare 免费收发临时域名邮箱' }],
+    ['meta', { name: 'twitter:image', content: 'https://temp-mail-docs.awsl.uk/logo.png' }],
+    ['link', { rel: 'alternate', hreflang: 'zh-Hans', href: 'https://temp-mail-docs.awsl.uk/zh/' }],
+    ['link', { rel: 'alternate', hreflang: 'en', href: 'https://temp-mail-docs.awsl.uk/en/' }],
+    ['link', { rel: 'alternate', hreflang: 'x-default', href: 'https://temp-mail-docs.awsl.uk/zh/' }],
   ],
   sitemap: {
     hostname: 'https://temp-mail-docs.awsl.uk',

--- a/vitepress-docs/docs/.vitepress/en.ts
+++ b/vitepress-docs/docs/.vitepress/en.ts
@@ -3,7 +3,12 @@ import { defineConfig, type DefaultTheme } from 'vitepress'
 export const en = defineConfig({
     title: "Temp Mail Doc",
     lang: 'en-US',
-    description: 'CloudFlare Free sending and receiving of temporary domain name mailboxes',
+    description: 'Free temporary domain email powered by CloudFlare Workers, with multi-domain, attachments, Telegram Bot, Webhook, SMTP/IMAP support',
+
+    head: [
+        ['meta', { property: 'og:locale', content: 'en_US' }],
+        ['meta', { property: 'og:description', content: 'Free temporary domain email powered by CloudFlare Workers, with multi-domain, attachments, Telegram Bot, Webhook, SMTP/IMAP support' }],
+    ],
 
     themeConfig: {
         nav: nav(),

--- a/vitepress-docs/docs/.vitepress/zh.ts
+++ b/vitepress-docs/docs/.vitepress/zh.ts
@@ -3,7 +3,12 @@ import { defineConfig, type DefaultTheme } from 'vitepress'
 export const zh = defineConfig({
     title: "临时邮箱文档",
     lang: 'zh-Hans',
-    description: 'CloudFlare 免费收发 临时域名邮箱',
+    description: 'CloudFlare 免费收发临时域名邮箱，支持多域名、附件、Telegram Bot、Webhook、SMTP/IMAP',
+
+    head: [
+        ['meta', { property: 'og:locale', content: 'zh_CN' }],
+        ['meta', { property: 'og:description', content: 'CloudFlare 免费收发临时域名邮箱，支持多域名、附件、Telegram Bot、Webhook、SMTP/IMAP' }],
+    ],
 
     themeConfig: {
         nav: nav(),

--- a/vitepress-docs/docs/index.md
+++ b/vitepress-docs/docs/index.md
@@ -1,31 +1,11 @@
 ---
-# https://vitepress.dev/reference/default-theme-home-page
-layout: home
-
-hero:
-  name: "临时邮箱文档"
-  tagline: "搭建 CloudFlare 免费收发 临时域名邮箱"
-  actions:
-    - theme: brand
-      text: 立即试用
-      link: https://mail.awsl.uk/
-    - theme: alt
-      text: 命令行部署
-      link: /zh/guide/quick-start
-    - theme: alt
-      text: 通过用户界面部署
-      link: /zh/guide/quick-start
-    - theme: alt
-      text: 通过 Github Actions 部署
-      link: /zh/guide/quick-start
-
-features:
-  - title: 仅需域名即可私有部署, 免费托管在 CloudFlare，无需服务器
-    details: 支持 password 登录邮箱, 用户注册，使用访问密码可作为私人站点，支持附件功能。
-  - title:  使用 rust wasm 解析邮件
-    details: 使用 rust wasm 解析邮件，支持邮件各种RFC标准，支持附件, 速度极快
-  - title:  支持 Telegram Bot 和 Webhook
-    details: 邮件可转发到 Telegram 或者 webhook, Telegram Bot 支持绑定邮箱，查看邮件, Telegram 小程序
-  - title: 支持发送邮件(UI/API/SMTP)
-    details: 支持通过域名邮箱发送 txt 或者 html 邮件，支持 DKIM 签名, UI/API/SMTP 发送邮件
+layout: page
 ---
+
+<script setup>
+import { onMounted } from 'vue'
+
+onMounted(() => {
+  window.location.replace('/zh/')
+})
+</script>


### PR DESCRIPTION
## Summary
- Fix `og:locale` value (was `Temp Mail Doc`, now `zh_CN`)
- Add `description` meta, `og:description`, `twitter:card/title/description/image`
- Add `robots` meta, `hreflang` alternate links for zh/en/x-default
- Add per-locale `og:locale` and `og:description` in zh.ts and en.ts
- Improve English description (was broken English)
- Redirect root `/` to `/zh/` for better UX

## Test plan
- [ ] Check page source for correct meta tags on `/zh/` and `/en/` pages
- [ ] Verify root `/` redirects to `/zh/`
- [ ] Test sharing a page link and verify title/description preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)