### PR TITLE
fix: add missing message_id index to DB init and migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 
 - fix: |Admin API| 修复 `/admin/account_settings` 在未配置 KV 且 `fromBlockList` 为空时触发 `Cannot read properties of undefined (reading 'put')` 的问题
+- fix: |数据库| 修复 `DB_INIT_QUERIES` 缺少 `idx_raw_mails_message_id` 索引导致 `UPDATE raw_mails ... WHERE message_id = ?` 全表扫描的问题，同步 `schema.sql` 与初始化代码，新增 v0.0.6 迁移逻辑
 - fix: |文档| 修复 User Mail API 文档中错误使用 `x-admin-auth` 的问题，改为正确的 `x-user-token`
 - docs: |文档| 新增 Admin 删除邮件、删除邮箱地址、清空收件箱、清空发件箱 API 文档
 

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 
 - fix: |Admin API| Fix `/admin/account_settings` throwing `Cannot read properties of undefined (reading 'put')` when KV is not configured and `fromBlockList` is empty
+- fix: |Database| Fix missing `idx_raw_mails_message_id` index in `DB_INIT_QUERIES` causing full table scan on `UPDATE raw_mails ... WHERE message_id = ?`, sync `schema.sql` with init code, add v0.0.6 migration
 - fix: |Docs| Fix User Mail API documentation incorrectly using `x-admin-auth`, changed to correct `x-user-token`
 - docs: |Docs| Add Admin API documentation for delete mail, delete address, clear inbox, and clear sent items
 

--- a/worker/src/admin_api/db_api.ts
+++ b/worker/src/admin_api/db_api.ts
@@ -17,6 +17,8 @@ CREATE INDEX IF NOT EXISTS idx_raw_mails_address ON raw_mails(address);
 
 CREATE INDEX IF NOT EXISTS idx_raw_mails_created_at ON raw_mails(created_at);
 
+CREATE INDEX IF NOT EXISTS idx_raw_mails_message_id ON raw_mails(message_id);
+
 CREATE TABLE IF NOT EXISTS address (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT UNIQUE,
@@ -177,6 +179,10 @@ export default {
                 await c.env.DB.exec(`ALTER TABLE address ADD COLUMN source_meta TEXT;`);
                 await c.env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_address_source_meta ON address(source_meta);`);
             }
+        }
+        if (version && version <= "v0.0.5") {
+            // migration to v0.0.6: add message_id index on raw_mails
+            await c.env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_raw_mails_message_id ON raw_mails(message_id);`);
         }
         if (version != CONSTANTS.DB_VERSION) {
             // remove all \r and \n characters from the query string

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -3,7 +3,7 @@ export const CONSTANTS = {
 
     // DB Version
     DB_VERSION_KEY: 'db_version',
-    DB_VERSION: "v0.0.5",
+    DB_VERSION: "v0.0.6",
 
     // DB settings
     ADDRESS_BLOCK_LIST_KEY: 'address_block_list',


### PR DESCRIPTION
## Summary
- Add missing `idx_raw_mails_message_id` index to `DB_INIT_QUERIES` in `db_api.ts`, syncing with `schema.sql`
- Add v0.0.6 DB migration to create the index for existing deployments
- Bump `DB_VERSION` from `v0.0.5` to `v0.0.6`
- Update Chinese and English changelogs

## Test plan
- [ ] Verify new DB initialization creates the `message_id` index
- [ ] Verify migration from v0.0.5 to v0.0.6 creates the index
- [ ] Run `EXPLAIN QUERY PLAN UPDATE raw_mails SET metadata = 'test' WHERE message_id = 'test'` to confirm index usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)