### PR TITLE
docs: add private site password hint to all API docs

### DIFF
--- a/vitepress-docs/docs/en/guide/feature/mail-api.md
+++ b/vitepress-docs/docs/en/guide/feature/mail-api.md
@@ -11,7 +11,7 @@ res = requests.get(
     f"https://<your-worker-address>/api/mails?limit={limit}&offset={offset}",
     headers={
         "Authorization": f"Bearer {your-JWT-password}",
-        # "x-custom-auth": "<your-website-password>", # If custom password is enabled
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
         "Content-Type": "application/json"
     }
 )
@@ -33,7 +33,10 @@ querystring = {
     "address":"xxxx@awsl.uk"
 }
 
-headers = {"x-admin-auth": "<your-Admin-password>"}
+headers = {
+        "x-admin-auth": "<your-Admin-password>",
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
+    }
 
 response = requests.get(url, headers=headers, params=querystring)
 
@@ -52,7 +55,10 @@ import requests
 mail_id = 1
 url = f"https://<your-worker-address>/admin/mails/{mail_id}"
 
-headers = {"x-admin-auth": "<your-Admin-password>"}
+headers = {
+        "x-admin-auth": "<your-Admin-password>",
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -69,7 +75,10 @@ import requests
 address_id = 1
 url = f"https://<your-worker-address>/admin/delete_address/{address_id}"
 
-headers = {"x-admin-auth": "<your-Admin-password>"}
+headers = {
+        "x-admin-auth": "<your-Admin-password>",
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -86,7 +95,10 @@ import requests
 address_id = 1
 url = f"https://<your-worker-address>/admin/clear_inbox/{address_id}"
 
-headers = {"x-admin-auth": "<your-Admin-password>"}
+headers = {
+        "x-admin-auth": "<your-Admin-password>",
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -103,7 +115,10 @@ import requests
 address_id = 1
 url = f"https://<your-worker-address>/admin/clear_sent_items/{address_id}"
 
-headers = {"x-admin-auth": "<your-Admin-password>"}
+headers = {
+        "x-admin-auth": "<your-Admin-password>",
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -126,7 +141,10 @@ querystring = {
     "address":"xxxx@awsl.uk"
 }
 
-headers = {"x-user-token": "<your-user-JWT-token>"}
+headers = {
+        "x-user-token": "<your-user-JWT-token>",
+        # "x-custom-auth": "<your-website-password>", # If private site password is enabled
+    }
 
 response = requests.get(url, headers=headers, params=querystring)
 

--- a/vitepress-docs/docs/en/guide/feature/new-address-api.md
+++ b/vitepress-docs/docs/en/guide/feature/new-address-api.md
@@ -16,6 +16,7 @@ res = requests.post(
     },
     headers={
         'x-admin-auth': "<your_website_admin_password>",
+        # "x-custom-auth": "<your_website_password>", # If private site password is enabled
         "Content-Type": "application/json"
     }
 )
@@ -59,6 +60,7 @@ def fetch_email_data(name):
             },
             headers={
                 'x-admin-auth': "<your_website_admin_password>",
+                # "x-custom-auth": "<your_website_password>", # If private site password is enabled
                 "Content-Type": "application/json"
             }
         )

--- a/vitepress-docs/docs/en/guide/feature/send-mail-api.md
+++ b/vitepress-docs/docs/en/guide/feature/send-mail-api.md
@@ -18,7 +18,7 @@ res = requests.post(
     "http://localhost:8787/api/send_mail",
     json=send_body, headers={
         "Authorization": f"Bearer {your_JWT_password}",
-        # "x-custom-auth": "<your_website_password>", # If custom password is enabled
+        # "x-custom-auth": "<your_website_password>", # If private site password is enabled
         "Content-Type": "application/json"
     }
 )
@@ -36,6 +36,7 @@ send_body = {
 res = requests.post(
     "http://localhost:8787/external/api/send_mail",
     json=send_body, headers={
+        # "x-custom-auth": "<your_website_password>", # If private site password is enabled
         "Content-Type": "application/json"
     }
 )

--- a/vitepress-docs/docs/zh/guide/feature/mail-api.md
+++ b/vitepress-docs/docs/zh/guide/feature/mail-api.md
@@ -11,7 +11,7 @@ res = requests.get(
     f"https://<你的worker地址>/api/mails?limit={limit}&offset={offset}",
     headers={
         "Authorization": f"Bearer {你的JWT密码}",
-        # "x-custom-auth": "<你的网站密码>", # 如果启用了自定义密码
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
         "Content-Type": "application/json"
     }
 )
@@ -33,7 +33,10 @@ querystring = {
     "address":"xxxx@awsl.uk"
 }
 
-headers = {"x-admin-auth": "<你的Admin密码>"}
+headers = {
+        "x-admin-auth": "<你的Admin密码>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
+    }
 
 response = requests.get(url, headers=headers, params=querystring)
 
@@ -52,7 +55,10 @@ import requests
 mail_id = 1
 url = f"https://<你的worker地址>/admin/mails/{mail_id}"
 
-headers = {"x-admin-auth": "<你的Admin密码>"}
+headers = {
+        "x-admin-auth": "<你的Admin密码>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -69,7 +75,10 @@ import requests
 address_id = 1
 url = f"https://<你的worker地址>/admin/delete_address/{address_id}"
 
-headers = {"x-admin-auth": "<你的Admin密码>"}
+headers = {
+        "x-admin-auth": "<你的Admin密码>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -86,7 +95,10 @@ import requests
 address_id = 1
 url = f"https://<你的worker地址>/admin/clear_inbox/{address_id}"
 
-headers = {"x-admin-auth": "<你的Admin密码>"}
+headers = {
+        "x-admin-auth": "<你的Admin密码>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -103,7 +115,10 @@ import requests
 address_id = 1
 url = f"https://<你的worker地址>/admin/clear_sent_items/{address_id}"
 
-headers = {"x-admin-auth": "<你的Admin密码>"}
+headers = {
+        "x-admin-auth": "<你的Admin密码>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
+    }
 
 response = requests.delete(url, headers=headers)
 
@@ -126,7 +141,10 @@ querystring = {
     "address":"xxxx@awsl.uk"
 }
 
-headers = {"x-user-token": "<你的用户JWT Token>"}
+headers = {
+        "x-user-token": "<你的用户JWT Token>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
+    }
 
 response = requests.get(url, headers=headers, params=querystring)
 

--- a/vitepress-docs/docs/zh/guide/feature/new-address-api.md
+++ b/vitepress-docs/docs/zh/guide/feature/new-address-api.md
@@ -16,6 +16,7 @@ res = requests.post(
     },
     headers={
         'x-admin-auth': "<你的网站admin密码>",
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
         "Content-Type": "application/json"
     }
 )
@@ -59,6 +60,7 @@ def fetch_email_data(name):
             },
             headers={
                 'x-admin-auth': "<你的网站admin密码>",
+                # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
                 "Content-Type": "application/json"
             }
         )

--- a/vitepress-docs/docs/zh/guide/feature/send-mail-api.md
+++ b/vitepress-docs/docs/zh/guide/feature/send-mail-api.md
@@ -18,7 +18,7 @@ res = requests.post(
     "http://localhost:8787/api/send_mail",
     json=send_body, headers={
         "Authorization": f"Bearer {你的JWT密码}",
-        # "x-custom-auth": "<你的网站密码>", # 如果启用了自定义密码
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
         "Content-Type": "application/json"
     }
 )
@@ -36,6 +36,7 @@ send_body = {
 res = requests.post(
     "http://localhost:8787/external/api/send_mail",
     json=send_body, headers={
+        # "x-custom-auth": "<你的网站密码>", # 如果启用了私有站点密码
         "Content-Type": "application/json"
     }
 )


### PR DESCRIPTION
## Summary
- Add `x-custom-auth` (private site password) comment hints to all API documentation examples that were missing it
- Unified wording from "custom password" to "private site password" for consistency
- Covers both Chinese and English docs: `mail-api.md`, `send-mail-api.md`, `new-address-api.md`

## Details
When `PASSWORDS` is configured, all `/api/*`, `/user_api/*`, `/admin/*`, `/external/*` endpoints require the `x-custom-auth` header. Previously, only a few API examples mentioned this. Now all API code examples include the commented hint.

## Test plan
- [ ] Verify docs render correctly in VitePress
- [ ] Check all 6 doc files have consistent `x-custom-auth` comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)