### PR TITLE
test: add E2E tests for mail deletion and inbox clearing

### DIFF
--- a/e2e/tests/api/mail-deletion.spec.ts
+++ b/e2e/tests/api/mail-deletion.spec.ts
@@ -5,69 +5,76 @@ test.describe('Mail Deletion', () => {
   test('delete a single mail by ID', async ({ request }) => {
     const { jwt, address } = await createTestAddress(request, 'del-single');
 
-    // Seed 3 emails
-    for (let i = 1; i <= 3; i++) {
-      await seedTestMail(request, address, { subject: `Mail ${i}` });
+    try {
+      // Seed 3 emails
+      for (let i = 1; i <= 3; i++) {
+        await seedTestMail(request, address, { subject: `Mail ${i}` });
+      }
+
+      // List mails — should have 3
+      const listRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(listRes.ok()).toBe(true);
+      const { results } = await listRes.json();
+      expect(results).toHaveLength(3);
+
+      // Delete the second mail
+      const targetId = results[1].id;
+      const delRes = await request.delete(`${WORKER_URL}/api/mails/${targetId}`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(delRes.ok()).toBe(true);
+      const delBody = await delRes.json();
+      expect(delBody.success).toBe(true);
+
+      // List again — should have 2, and the deleted ID should be gone
+      const afterRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(afterRes.ok()).toBe(true);
+      const after = await afterRes.json();
+      expect(after.results).toHaveLength(2);
+      expect(after.results.every((m: any) => m.id !== targetId)).toBe(true);
+    } finally {
+      await deleteAddress(request, jwt);
     }
-
-    // List mails — should have 3
-    const listRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-    expect(listRes.ok()).toBe(true);
-    const { results } = await listRes.json();
-    expect(results).toHaveLength(3);
-
-    // Delete the second mail
-    const targetId = results[1].id;
-    const delRes = await request.delete(`${WORKER_URL}/api/mails/${targetId}`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-    expect(delRes.ok()).toBe(true);
-    const delBody = await delRes.json();
-    expect(delBody.success).toBe(true);
-
-    // List again — should have 2, and the deleted ID should be gone
-    const afterRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-    const after = await afterRes.json();
-    expect(after.results).toHaveLength(2);
-    expect(after.results.every((m: any) => m.id !== targetId)).toBe(true);
-
-    await deleteAddress(request, jwt);
   });
 
   test('clear entire inbox', async ({ request }) => {
     const { jwt, address } = await createTestAddress(request, 'del-clear');
 
-    // Seed 3 emails
-    for (let i = 1; i <= 3; i++) {
-      await seedTestMail(request, address, { subject: `Mail ${i}` });
+    try {
+      // Seed 3 emails
+      for (let i = 1; i <= 3; i++) {
+        await seedTestMail(request, address, { subject: `Mail ${i}` });
+      }
+
+      // Verify 3 mails exist
+      const listRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(listRes.ok()).toBe(true);
+      const { results } = await listRes.json();
+      expect(results).toHaveLength(3);
+
+      // Clear inbox
+      const clearRes = await request.delete(`${WORKER_URL}/api/clear_inbox`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(clearRes.ok()).toBe(true);
+      const clearBody = await clearRes.json();
+      expect(clearBody.success).toBe(true);
+
+      // Verify inbox is empty
+      const afterRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(afterRes.ok()).toBe(true);
+      const after = await afterRes.json();
+      expect(after.results).toHaveLength(0);
+    } finally {
+      await deleteAddress(request, jwt);
     }
-
-    // Verify 3 mails exist
-    const listRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-    const { results } = await listRes.json();
-    expect(results).toHaveLength(3);
-
-    // Clear inbox
-    const clearRes = await request.delete(`${WORKER_URL}/api/clear_inbox`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-    expect(clearRes.ok()).toBe(true);
-    const clearBody = await clearRes.json();
-    expect(clearBody.success).toBe(true);
-
-    // Verify inbox is empty
-    const afterRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
-      headers: { Authorization: `Bearer ${jwt}` },
-    });
-    const after = await afterRes.json();
-    expect(after.results).toHaveLength(0);
-
-    await deleteAddress(request, jwt);
   });
 });


### PR DESCRIPTION
## Summary
- Add `e2e/tests/api/mail-deletion.spec.ts` with two test cases:
  - **Delete single mail**: create address → seed 3 emails → delete one by ID → verify 2 remain
  - **Clear inbox**: create address → seed 3 emails → clear inbox → verify 0 remain
- Tests cover `DELETE /api/mails/:id` and `DELETE /api/clear_inbox` endpoints
- All 8 E2E tests pass (6 existing + 2 new)

## Test plan
- [x] Ran full E2E suite locally via `docker compose` — 8/8 passed in 11.3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 添加端到端测试套件，覆盖邮件删除场景：按 ID 删除单封邮件与清空整个收件箱。测试通过接口执行操作并验证响应状态与最终邮箱状态，包含数据准备与清理步骤以确保环境一致性和可重复性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->