### PR TITLE
test: add E2E tests for fetching single mail by ID

### DIFF
--- a/e2e/tests/api/mail-detail.spec.ts
+++ b/e2e/tests/api/mail-detail.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { WORKER_URL, createTestAddress, seedTestMail, deleteAddress } from '../../fixtures/test-helpers';
+
+test.describe('Mail Detail', () => {
+  test('fetch a single mail by ID', async ({ request }) => {
+    const { jwt, address } = await createTestAddress(request, 'detail-get');
+
+    try {
+      // Seed a mail with known content
+      await seedTestMail(request, address, {
+        subject: 'Detail Test',
+        from: 'alice@test.example.com',
+        html: '<p>Hello detail</p>',
+        text: 'Hello detail',
+      });
+
+      // List mails to get the ID
+      const listRes = await request.get(`${WORKER_URL}/api/mails?limit=10&offset=0`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(listRes.ok()).toBe(true);
+      const { results } = await listRes.json();
+      expect(results).toHaveLength(1);
+      const mailId = results[0].id;
+
+      // Fetch single mail by ID
+      const detailRes = await request.get(`${WORKER_URL}/api/mail/${mailId}`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(detailRes.ok()).toBe(true);
+      const mail = await detailRes.json();
+      expect(mail.id).toBe(mailId);
+      expect(mail.address).toBe(address);
+      expect(mail.source).toBe('alice@test.example.com');
+      expect(mail.raw).toContain('Detail Test');
+    } finally {
+      await deleteAddress(request, jwt);
+    }
+  });
+
+  test('fetch non-existent mail returns null', async ({ request }) => {
+    const { jwt } = await createTestAddress(request, 'detail-404');
+
+    try {
+      const res = await request.get(`${WORKER_URL}/api/mail/99999999`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      expect(res.ok()).toBe(true);
+      const body = await res.json();
+      expect(body).toBeNull();
+    } finally {
+      await deleteAddress(request, jwt);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `e2e/tests/api/mail-detail.spec.ts` with two test cases:
  - **Fetch mail by ID**: seed a mail → list to get ID → fetch by ID → verify fields (id, address, source, raw content)
  - **Non-existent ID**: fetch with invalid ID → verify returns null
- Covers `GET /api/mail/:mail_id` endpoint
- All 10 E2E tests pass (8 existing + 2 new)

## Test plan
- [x] Ran full E2E suite locally via `docker compose` — 10/10 passed in 12.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added端到端测试以验证邮件详情API的功能和行为，包括邮件ID获取、字段验证以及非存在邮件的处理逻辑。测试包含完整的清理机制确保资源释放。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->