### PR TITLE
test: add E2E test for duplicate send access request

### DIFF
--- a/e2e/tests/api/send-access.spec.ts
+++ b/e2e/tests/api/send-access.spec.ts
@@ -22,6 +22,8 @@ test.describe('Send Access', () => {
         headers: { Authorization: `Bearer ${jwt}` },
       });
       expect(dupRes.status()).toBe(400);
+      const dupBody = await dupRes.text();
+      expect(dupBody).toContain('Already');
     } finally {
       await deleteAddress(request, jwt);
     }


### PR DESCRIPTION
## Summary
- Add `e2e/tests/api/send-access.spec.ts` with one test case:
  - **Duplicate send access**: request send access → verify balance = 10 → request again → verify 400 (UNIQUE constraint)
- Covers `POST /api/requset_send_mail_access` error path
- All E2E tests pass

## Test plan
- [x] Ran full E2E suite locally via `docker compose` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 新增“发送访问权限”端到端测试，覆盖授权验证、发送流程成功场景、重复请求/错误响应场景，以及确保无论测试结果均进行清理的异常处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->