### PR TITLE
test: add E2E test for clearing sent items

### DIFF
--- a/e2e/tests/api/clear-sent.spec.ts
+++ b/e2e/tests/api/clear-sent.spec.ts
@@ -14,7 +14,7 @@ test.describe('Clear Sent Items', () => {
   });
 
   test('send mail then clear sent items', async ({ request }) => {
-    const { jwt, address } = await createTestAddress(request, 'clear-sent');
+    const { jwt } = await createTestAddress(request, 'clear-sent');
     await requestSendAccess(request, jwt);
 
     try {


### PR DESCRIPTION
## Summary
- Add `e2e/tests/api/clear-sent.spec.ts` with one test case:
  - **Clear sent items**: send mail → verify in sendbox → `DELETE /api/clear_sent_items` → verify sendbox empty
- Covers `GET /api/sendbox` and `DELETE /api/clear_sent_items` endpoints
- All E2E tests pass

## Test plan
- [x] Ran full E2E suite locally via `docker compose` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 增加了端到端测试套件，用于验证清除已发送邮件功能的正常工作，确保用户可以成功清空已发送项目列表。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->