### PR TITLE
chore(deps): bump playwright from 1.49.0 to 1.58.2

### DIFF
--- a/e2e/Dockerfile.e2e
+++ b/e2e/Dockerfile.e2e
@@ -1,5 +1,5 @@
 # Keep this version in sync with @playwright/test in package.json
-FROM mcr.microsoft.com/playwright:v1.49.0-noble
+FROM mcr.microsoft.com/playwright:v1.58.2-noble
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -10,7 +10,7 @@
         "nodemailer": "^8.0.1"
       },
       "devDependencies": {
-        "@playwright/test": "1.49.0",
+        "@playwright/test": "1.58.2",
         "@types/nodemailer": "^7.0.11",
         "@types/ws": "^8.5.0",
         "ws": "^8.18.0"
@@ -23,13 +23,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.0"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -246,13 +246,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "test:down": "docker compose down -v"
   },
   "devDependencies": {
-    "@playwright/test": "1.49.0",
+    "@playwright/test": "1.58.2",
     "@types/nodemailer": "^7.0.11",
     "@types/ws": "^8.5.0",
     "ws": "^8.18.0"


### PR DESCRIPTION
## Summary
- Bump `@playwright/test` and `playwright` from 1.49.0 to 1.58.2
- Update `Dockerfile.e2e` base image from `playwright:v1.49.0-noble` to `playwright:v1.58.2-noble` to match
- Fixes CI failure in #864 where browser executable was missing due to version mismatch

Dependabot PR #864 only updated `package.json` / `package-lock.json` but missed the Docker base image, causing `browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1208/...`. This PR includes all three files.

Supersedes #864.

## Test plan
- [x] Full E2E suite passes locally (19/19)
- [x] CI should pass with matching Playwright + Docker image versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **维护工作**
  * 升级了自动化测试框架版本，从1.49.0更新至1.58.2，确保测试环境与最新工具保持兼容并获得性能改进

<!-- end of auto-generated comment: release notes by coderabbit.ai -->