### PR TITLE
test: add E2E tests for webhook trigger on incoming mail

### DIFF
--- a/e2e/tests/api/webhook-trigger.spec.ts
+++ b/e2e/tests/api/webhook-trigger.spec.ts
@@ -13,7 +13,7 @@ import {
  */
 async function startWebhookReceiver(): Promise<{
   server: http.Server;
-  firstRequest: Promise<{ body: string; method: string; headers: http.IncomingHttpHeaders }>;
+  firstRequest: Promise<{ body: string; method: string; path: string; headers: http.IncomingHttpHeaders }>;
   url: string;
 }> {
   let resolve: (val: any) => void;
@@ -26,6 +26,7 @@ async function startWebhookReceiver(): Promise<{
       resolve({
         body: Buffer.concat(chunks).toString('utf-8'),
         method: req.method || '',
+        path: req.url || '',
         headers: req.headers,
       });
       res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -99,6 +100,7 @@ test.describe('Webhook — triggered on incoming mail', () => {
       // Wait for webhook to be called
       const received = await firstRequest;
       expect(received.method).toBe('POST');
+      expect(received.path).toBe('/webhook');
 
       const payload = JSON.parse(received.body);
       expect(payload.from).toContain('webhook-sender@test.example.com');


### PR DESCRIPTION
## Summary
- Add E2E tests for webhook trigger: verify webhook is called with correct payload when mail arrives, and NOT called when disabled
- Use dynamic port allocation (port 0) for webhook receiver to avoid port conflicts
- Assert webhook request path `/webhook` to prevent false positives
- Clean up `e2e_test_api.ts`: remove unused WorkerMailer/MIME parsing code, simplify mock `reply()` to no-op

## Test plan
- [x] `webhook is called with correct payload when mail arrives` — configures webhook, sends mail via `receive_mail`, verifies HTTP POST with correct from/to/subject
- [x] `webhook is NOT called when disabled` — disables webhook, sends mail, verifies no HTTP call within 3s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)