### PR TITLE
fix: passkey user verification compatibility for v13

### DIFF
--- a/worker/src/user_api/passkey.ts
+++ b/worker/src/user_api/passkey.ts
@@ -88,7 +88,7 @@ export default {
                 return true;
             },
             expectedOrigin: origin,
-            requireUserVerification: true,
+            requireUserVerification: false,
         });
         const { verified, registrationInfo } = verification;
 
@@ -162,6 +162,7 @@ export default {
             },
             expectedOrigin: origin,
             expectedRPID: domain,
+            requireUserVerification: false,
             credential: {
                 id: passkeyData.id,
                 publicKey: isoBase64URL.toBuffer(passkeyData.publicKey),


### PR DESCRIPTION
## Summary
- Set `requireUserVerification: false` in both `verifyRegistrationResponse` and `verifyAuthenticationResponse`
- Fixes 500 error: "User verification required, but user could not be verified"
- `@simplewebauthn/server` v13 changed the default to `true`, breaking existing passkeys and authenticators without UV support

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了通行密钥注册流程的验证要求，降低了用户验证的严格程度。
  * 优化了通行密钥认证流程的验证要求，降低了用户验证的严格程度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->