### PR TITLE
fix: user email regex setting visibility

### DIFF
--- a/frontend/src/views/admin/UserSettings.vue
+++ b/frontend/src/views/admin/UserSettings.vue
@@ -21,7 +21,7 @@ const { t } = useI18n({
             manualInputPrompt: 'Type and press Enter to add',
             mailAllowList: 'Mail Address Allow List',
             maxAddressCount: 'Maximum number of email addresses that can be binded',
-            emailCheckRegex: 'Email Check Regex (e.g. ^[^.]+@.+$ to disallow dots before @)',
+            emailCheckRegex: "Email Check Regex (e.g. ^[^.]+{'@'}.+$ to disallow dots before {'@'})",
             enableEmailCheckRegex: 'Enable Email Check Regex',
         },
         zh: {
@@ -35,7 +35,7 @@ const { t } = useI18n({
             manualInputPrompt: '输入后按回车键添加',
             mailAllowList: '邮件地址白名单',
             maxAddressCount: '可绑定最大邮箱地址数量',
-            emailCheckRegex: '邮箱正则校验 (例如 ^[^.]+@.+$ 禁止@前面有.)',
+            emailCheckRegex: "邮箱正则校验 (例如 ^[^.]+{'@'}.+$ 禁止{'@'}前面有.)",
             enableEmailCheckRegex: '启用邮箱正则校验',
         }
     }
@@ -132,14 +132,14 @@ onMounted(async () => {
                     </n-input-group>
                 </n-form-item-row>
                 <n-form-item-row :label="t('enableEmailCheckRegex')">
-                    <n-input-group>
-                        <n-checkbox v-model:checked="userSettings.enableEmailCheckRegex" style="width: 20%;">
+                    <n-flex align="center" :wrap="false" style="width: 100%;">
+                        <n-checkbox v-model:checked="userSettings.enableEmailCheckRegex" style="flex: 0 0 auto;">
                             {{ t('enable') }}
                         </n-checkbox>
                         <n-input v-model:value="userSettings.emailCheckRegex"
-                            v-if="userSettings.enableEmailCheckRegex"
-                            style="width: 80%;" :placeholder="t('emailCheckRegex')" />
-                    </n-input-group>
+                            v-show="userSettings.enableEmailCheckRegex"
+                            style="flex: 1 1 auto;" :placeholder="t('emailCheckRegex')" />
+                    </n-flex>
                 </n-form-item-row>
             </n-form>
         </n-card>


### PR DESCRIPTION
## Summary
- keep the email regex validation option visible after enabling it in admin user settings
- escape literal @ characters in the i18n help text to avoid vue-i18n message compilation errors

## Verification
- npm run build (frontend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了邮箱检查选项的用户界面布局，改进了复选框与输入框的排列方式。
  * 增强了输入框的显示效果，使其响应式设计更加流畅。

* **样式**
  * 调整了相关控件的间距和对齐方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->