### PR TITLE
fix: update address timestamp on send mail and refactor TG attachment guard

### DIFF
--- a/worker/src/mails_api/send_mail_api.ts
+++ b/worker/src/mails_api/send_mail_api.ts
@@ -8,7 +8,7 @@ import i18n from '../i18n';
 import { CONSTANTS } from '../constants'
 import { getJsonSetting, getDomains, getIntValue, getBooleanValue, getStringValue, getJsonObjectValue, getSplitStringListValue } from '../utils';
 import { GeoData } from '../models'
-import { handleListQuery } from '../common'
+import { handleListQuery, updateAddressUpdatedAt } from '../common'
 
 
 export const api = new Hono<HonoCustomType>()
@@ -222,6 +222,8 @@ export const sendMail = async (
             console.warn(`Failed to update balance for ${address}`);
         }
     }
+    // update address updated_at
+    updateAddressUpdatedAt(c, address);
     // save to sendbox
     try {
         const reqIp = c.req.raw.headers.get("cf-connecting-ip")

--- a/worker/src/telegram_api/telegram.ts
+++ b/worker/src/telegram_api/telegram.ts
@@ -439,28 +439,29 @@ export async function sendMailToTelegram(
             ...Markup.inlineKeyboard([...buttons])
         });
         // send attachments
-        if (!getBooleanValue(c.env.ENABLE_TG_PUSH_ATTACHMENT)) return;
-        const validAttachments = attachments.filter(att => {
-            if (att.content.byteLength > TG_MAX_FILE_SIZE) {
-                console.log(`Skipping attachment ${att.filename}: ${(att.content.byteLength / 1024 / 1024).toFixed(1)}MB exceeds 50MB limit`);
-                return false;
-            }
-            return true;
-        });
-        if (validAttachments.length > 0) {
-            const caption = `From: ${parsedEmailContext.parsedEmail?.sender || ""}\nSubject: ${parsedEmailContext.parsedEmail?.subject || ""}`;
-            const batchSize = 6;
-            for (let i = 0; i < validAttachments.length; i += batchSize) {
-                const batch = validAttachments.slice(i, i + batchSize);
-                try {
-                    const mediaGroup: InputMediaDocument[] = batch.map((att, idx) => ({
-                        type: 'document',
-                        media: { source: Buffer.from(att.content), filename: att.filename },
-                        ...(i === 0 && idx === 0 ? { caption } : {}),
-                    }));
-                    await bot.telegram.sendMediaGroup(targetUserId, mediaGroup);
-                } catch (e) {
-                    console.error(`Failed to send attachment batch ${i / batchSize + 1}:`, e);
+        if (getBooleanValue(c.env.ENABLE_TG_PUSH_ATTACHMENT)) {
+            const validAttachments = attachments.filter(att => {
+                if (att.content.byteLength > TG_MAX_FILE_SIZE) {
+                    console.log(`Skipping attachment ${att.filename}: ${(att.content.byteLength / 1024 / 1024).toFixed(1)}MB exceeds 50MB limit`);
+                    return false;
+                }
+                return true;
+            });
+            if (validAttachments.length > 0) {
+                const caption = `From: ${parsedEmailContext.parsedEmail?.sender || ""}\nSubject: ${parsedEmailContext.parsedEmail?.subject || ""}`;
+                const batchSize = 6;
+                for (let i = 0; i < validAttachments.length; i += batchSize) {
+                    const batch = validAttachments.slice(i, i + batchSize);
+                    try {
+                        const mediaGroup: InputMediaDocument[] = batch.map((att, idx) => ({
+                            type: 'document',
+                            media: { source: Buffer.from(att.content), filename: att.filename },
+                            ...(i === 0 && idx === 0 ? { caption } : {}),
+                        }));
+                        await bot.telegram.sendMediaGroup(targetUserId, mediaGroup);
+                    } catch (e) {
+                        console.error(`Failed to send attachment batch ${i / batchSize + 1}:`, e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- 发送邮件成功后调用 `updateAddressUpdatedAt` 更新地址活跃时间，与收件行为一致
- 重构 Telegram 附件推送的环境变量检查：将 `return` 改为 `if` 包裹，避免未来扩展时跳过后续逻辑

## Changes

| File | Change |
|------|--------|
| `worker/src/mails_api/send_mail_api.ts` | Import and call `updateAddressUpdatedAt` after send mail |
| `worker/src/telegram_api/telegram.ts` | Replace early `return` with `if` block for attachment guard |

## Test plan

- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **Bug 修复**
  * 优化了邮件发送操作中地址信息的处理，确保数据保持最新
  * 改进了 Telegram 附件的发送机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->