### PR TITLE
docs: add changelog for OAuth2 sessionStorage fallback (#900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Bug Fixes
 
 - fix: |自动回复| 修复 `source_prefix` 为空字符串时自动回复不触发的问题（#459），空值现在正确匹配所有发件人
-- fix: |OAuth2| 修复 Android 等移动端浏览器 OAuth2 登录时 sessionStorage 丢失导致回调失败的问题，新增 localStorage 兜底（#900）
+- fix: |OAuth2| 修复 Android via 浏览器等移动端 OAuth2 登录时 sessionStorage 丢失导致回调失败的问题，新增 localStorage 兜底（#900）
 
 ### Testing
 

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -17,7 +17,7 @@
 ### Bug Fixes
 
 - fix: |Auto Reply| Fix auto-reply not triggering when `source_prefix` is empty string (#459), empty value now correctly matches all senders
-- fix: |OAuth2| Fix OAuth2 login callback failure on Android and other mobile browsers due to sessionStorage loss during redirect, add localStorage fallback (#900)
+- fix: |OAuth2| Fix OAuth2 login callback failure on Android via browser and other mobile browsers due to sessionStorage loss during redirect, add localStorage fallback (#900)
 
 ### Testing
 


### PR DESCRIPTION
### **User description**
## Summary
- Add changelog entries (zh + en) for PR #900: OAuth2 sessionStorage localStorage fallback on mobile browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Added changelog entries for OAuth2 sessionStorage fallback mechanism.

- Highlighted fixes for mobile browser OAuth2 login issues.

- Documented localStorage fallback implementation for reliability.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OAuth2Login["OAuth2 Login"] -- "sessionStorage fallback" --> localStorage["LocalStorage"]
  MobileBrowsers["Mobile Browsers"] -- "enhanced reliability" --> OAuth2Login
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Documented OAuth2 sessionStorage fallback in changelog</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry for OAuth2 sessionStorage fallback.<br> <li> Mentioned fix for mobile browser login issues.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/901/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Documented OAuth2 sessionStorage fallback in English changelog</code></dd></summary>
<hr>

CHANGELOG_EN.md

<ul><li>Added English changelog entry for OAuth2 sessionStorage fallback.<br> <li> Highlighted fix for mobile browser login callback failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/901/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug修复**
  * 修复了在Android和其他移动浏览器上OAuth2登录回调失败的问题。新增了localStorage备用方案，确保会话数据在重定向过程中不会丢失，提升移动设备上的登录稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->