### PR TITLE
docs: clarify mail API raw payload semantics

### DIFF
--- a/vitepress-docs/docs/en/guide/feature/mail-api.md
+++ b/vitepress-docs/docs/en/guide/feature/mail-api.md
@@ -17,6 +17,8 @@ res = requests.get(
 )
 ```
 
+**Note**: `/api/mails` returns raw RFC822 data by design (for example `source`/`raw`), and it does not guarantee parsed fields such as `subject`, `text`, or `html`. Parse the raw source on the client side (for example with `mail-parser-wasm` or `postal-mime`) if you need readable message content.
+
 ## Admin Mail API
 
 Supports `address` filter
@@ -42,6 +44,8 @@ response = requests.get(url, headers=headers, params=querystring)
 
 print(response.json())
 ```
+
+**Note**: `/admin/mails` follows the same design as `/api/mails`: it returns stored raw MIME data. If you need readable subject/body, parse the raw content on the client side.
 
 **Note**: Keyword filtering has been removed from the backend API. If you need to filter emails by content, please use the frontend filter input in the UI, which filters the currently displayed page.
 
@@ -150,5 +154,7 @@ response = requests.get(url, headers=headers, params=querystring)
 
 print(response.json())
 ```
+
+**Note**: `/user_api/mails` also returns raw RFC822 content from storage; parse it in your client to extract `subject`, `text`, and `html`.
 
 **Note**: Keyword filtering has been removed from the backend API. If you need to filter emails by content, please use the frontend filter input in the UI, which filters the currently displayed page.

--- a/vitepress-docs/docs/zh/guide/feature/mail-api.md
+++ b/vitepress-docs/docs/zh/guide/feature/mail-api.md
@@ -17,6 +17,8 @@ res = requests.get(
 )
 ```
 
+**注意**：`/api/mails` 按设计返回的是原始 RFC822 数据（如 `source`/`raw`），不保证直接包含 `subject`、`text`、`html` 等已解析字段。若要直接读取正文，请在客户端侧解析 `raw`（例如 `mail-parser-wasm`、`postal-mime`）。
+
 ## admin 邮件 API
 
 支持 `address` 过滤
@@ -42,6 +44,8 @@ response = requests.get(url, headers=headers, params=querystring)
 
 print(response.json())
 ```
+
+**注意**：`/admin/mails` 与 `/api/mails` 一致，返回的是邮件数据库中的 raw MIME 内容；如需正文/主题等可读字段，请在客户端自行解析 `raw`。
 
 **注意**：后端 API 已移除关键词过滤功能。如需按内容过滤邮件，请使用前端界面的过滤输入框，该功能可过滤当前显示的页面。
 
@@ -150,5 +154,7 @@ response = requests.get(url, headers=headers, params=querystring)
 
 print(response.json())
 ```
+
+**注意**：`/user_api/mails` 同样返回原始 RFC822 内容；请在客户端解析后提取 `subject`、`text`、`html`。
 
 **注意**：后端 API 已移除关键词过滤功能。如需按内容过滤邮件，请使用前端界面的过滤输入框，该功能可过滤当前显示的页面。


### PR DESCRIPTION
### **User description**
Docs update: document that /api/mails and related mail endpoints return raw RFC822 source and need client-side parsing.

Closes #905


___

### **PR Type**
Documentation


___

### **Description**
- Added clarification about raw RFC822 data returned by `/api/mails` and related endpoints.

- Explained the need for client-side parsing to extract readable email content.

- Updated both English and Chinese documentation for consistency.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  apiMails["/api/mails endpoint"] -- "returns raw RFC822 data" --> clientParsing["Client-side parsing required"]
  adminMails["/admin/mails endpoint"] -- "returns raw MIME data" --> clientParsing
  userApiMails["/user_api/mails endpoint"] -- "returns raw RFC822 content" --> clientParsing
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mail-api.md</strong><dd><code>Clarified raw RFC822 data handling in English docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vitepress-docs/docs/en/guide/feature/mail-api.md

<ul><li>Added notes clarifying <code>/api/mails</code> returns raw RFC822 data.<br> <li> Explained client-side parsing requirements for readable email content.<br> <li> Updated <code>/admin/mails</code> and <code>/user_api/mails</code> sections with similar <br>clarifications.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/906/files#diff-4f99106a49786d7fe64cf221bc1665491c1bfbdad2524e50aa6c59f0a7b3bf57">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mail-api.md</strong><dd><code>Clarified raw RFC822 data handling in Chinese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vitepress-docs/docs/zh/guide/feature/mail-api.md

<ul><li>Added notes clarifying <code>/api/mails</code> returns raw RFC822 data in Chinese.<br> <li> Explained client-side parsing requirements for readable email content.<br> <li> Updated <code>/admin/mails</code> and <code>/user_api/mails</code> sections with similar <br>clarifications.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/906/files#diff-6c591ac0d4b0ecd75a10ec850fbbd677d9d365fffa9aeddd1b3d9c63898c66bc">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **文档**
  * 澄清邮件接口返回原始 RFC822/MIME 格式内容，不保证包含已解析的字段（如主题、正文等）
  * 说明需要在客户端进行内容解析以获取可读的邮件信息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->