### PR TITLE
fix:Prevent shell from parsing configuration file errors

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -53,7 +53,7 @@ jobs:
           
           cd worker/
           # ✅ 修复核心：使用环境变量写入，避免 Shell 解析特殊字符
-          echo "$WRANGLER_TOML_CONTENT" > wrangler.toml
+          printf '%s\n' "$WRANGLER_TOML_CONTENT" > wrangler.toml
           
           pnpm install --no-frozen-lockfile
 


### PR DESCRIPTION
For example,my env is likes
```
[vars]
.
S3_SECRET_ACCESS_KEY = '''*UKg?ZBFDx~uCH]<7=<]N{6gq5#&+txmaskmkzcnmxznjdjxazcx'''

```

.When the action is executed, it is interpreted by the Shell, which leads to the failure of the action. This fix has changed to directly read the environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化后端部署工作流中对部署配置的处理与注入方式，改进环境变量传递，提升部署脚本的可靠性与安全性。

---

**注：** 本次更新为内部基础设施改进，对用户无直接影响。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->