### PR TITLE
fix: hash address password consistently in changePassword and login

### DIFF
--- a/worker/src/mails_api/address_auth.ts
+++ b/worker/src/mails_api/address_auth.ts
@@ -70,8 +70,19 @@ export default {
 
         // 验证密码
         const hashedInput = await hashPassword(password);
-        if (address.password !== hashedInput) {
+        const isHashedMatch = address.password === hashedInput;
+        const isLegacyPlaintextMatch = address.password === password;
+        if (!isHashedMatch && !isLegacyPlaintextMatch) {
             return c.text(msgs.InvalidEmailOrPasswordMsg, 401);
+        }
+
+        // 历史明文密码：登录成功后回写为哈希，完成在线迁移
+        if (isLegacyPlaintextMatch && !isHashedMatch) {
+            c.env.DB.prepare(
+                `UPDATE address SET password = ?, updated_at = datetime('now') WHERE id = ?`
+            ).bind(hashedInput, address.id).run().catch((err: Error) => {
+                console.error('Failed to migrate legacy plaintext password:', err);
+            });
         }
 
         // 创建JWT


### PR DESCRIPTION
## Summary

Address password authentication is **broken** due to inconsistent hash/plaintext handling:

| Operation | Stores | File |
|-----------|--------|------|
| `generatePasswordForAddress` | SHA-256 hash ✅ | `common.ts:265` |
| Admin `reset_password` | SHA-256 hash ✅ | `admin_api/index.ts:207` |
| **`changePassword`** | **Plaintext** ❌ | `address_auth.ts:29` |
| **`login`** | Compares **raw input vs stored value** | `address_auth.ts:71` |

**Result:** Auto-generated passwords (hashed) can never pass login (plaintext comparison). Login only works after `changePassword` (which stores plaintext), but breaks again after admin reset (which stores hash).

## Fix

- `changePassword`: hash `new_password` before storing (consistent with `generatePasswordForAddress` and admin `reset_password`)
- `login`: hash input before comparing with stored hash

## Migration Note

Users who previously used `changePassword` have plaintext passwords in the database. After this fix, they will need to change their password again (or admin can reset it). Newly created addresses and admin-reset passwords will work immediately.

## Test Plan

- [ ] Create address with auto-generated password → login → should succeed
- [ ] Change password via `changePassword` → login with new password → should succeed
- [ ] Admin reset password → login → should succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 提升密码安全性：账户密码改为使用哈希方式存储与验证，增强保护。
  * 支持老旧明文密码：登录时仍兼容旧明文并在成功后自动迁移为哈希密码，减少用户干预。
  * 迁移容错：在线迁移过程中错误将被捕获并记录，避免影响用户登录体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->