### PR TITLE
fix: avoid D1 LIKE pattern length limit on admin search (#956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- fix: |Admin| 修复 `/admin/address` 与 `/admin/users` 在使用完整邮箱（query 长度超过 50 字节）作为搜索条件时报错 `D1_ERROR: LIKE or GLOB pattern too complex` 的问题，长查询自动改用 `instr()` 绕开 D1 的 LIKE pattern 长度限制（#956）
+
 ### Improvements
 
 - docs: |发送邮件 API| 明确 `/api/send_mail` 与 `/external/api/send_mail` 两个端点的认证方式差异，补充"地址 JWT"概念说明（#922）

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- fix: |Admin| Fix `D1_ERROR: LIKE or GLOB pattern too complex` on `/admin/address` and `/admin/users` when searching by full email address (query length pushes the LIKE pattern over D1's 50-byte limit). Long queries now fall back to `instr()` to bypass the LIKE pattern length cap (#956)
+
 ### Improvements
 
 - docs: |Send Mail API| Clarify authentication differences between `/api/send_mail` and `/external/api/send_mail`, add "Address JWT" concept explanation (#922)

--- a/e2e/tests/api/admin-address-query.spec.ts
+++ b/e2e/tests/api/admin-address-query.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { WORKER_URL, TEST_DOMAIN, createTestAddress } from '../../fixtures/test-helpers';
+
+// Regression tests for #956: long admin search queries must not trigger
+// D1's "LIKE or GLOB pattern too complex" error.
+test.describe('Admin Address Query (#956)', () => {
+  test('short query (subdomain fragment) returns matching address via LIKE', async ({ request }) => {
+    const created = await createTestAddress(request, 'q956short');
+    const fragment = created.address.split('@')[0].slice(0, 8);
+
+    const res = await request.get(`${WORKER_URL}/admin/address`, {
+      params: { limit: '20', offset: '0', query: fragment },
+    });
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(Array.isArray(body.results)).toBe(true);
+    const names: string[] = body.results.map((r: any) => r.name);
+    expect(names).toContain(created.address);
+  });
+
+  test('long query (>50-byte pattern) does not crash with D1 LIKE error', async ({ request }) => {
+    const longQuery = 'a48r893s@5hx7zb.nationalgeographic.algomindtrade.com';
+    expect(new TextEncoder().encode(`%${longQuery}%`).length).toBeGreaterThan(50);
+
+    const res = await request.get(`${WORKER_URL}/admin/address`, {
+      params: { limit: '20', offset: '0', query: longQuery },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results.length).toBe(0);
+    expect(body.count).toBe(0);
+  });
+
+  test('long query also works for /admin/users', async ({ request }) => {
+    const longQuery = 'no-such-user-' + 'x'.repeat(40) + `@${TEST_DOMAIN}`;
+    expect(new TextEncoder().encode(`%${longQuery}%`).length).toBeGreaterThan(50);
+
+    const res = await request.get(`${WORKER_URL}/admin/users`, {
+      params: { limit: '20', offset: '0', query: longQuery },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results.length).toBe(0);
+    expect(body.count).toBe(0);
+  });
+});

--- a/worker/src/admin_api/admin_user_api.ts
+++ b/worker/src/admin_api/admin_user_api.ts
@@ -39,15 +39,21 @@ export default {
     getUsers: async (c: Context<HonoCustomType>) => {
         const { limit, offset, query } = c.req.query();
         if (query) {
+            // D1 caps LIKE pattern length at 50 bytes; fall back to instr()
+            // for longer queries to avoid "LIKE or GLOB pattern too complex" (#956).
+            const useInstr = new TextEncoder().encode(query).length + 2 > 50;
+            const param = useInstr ? query : `%${query}%`;
+            const userEmailWhere = useInstr ? `instr(u.user_email, ?) > 0` : `u.user_email like ?`;
+            const userEmailWhereCount = useInstr ? `instr(user_email, ?) > 0` : `user_email like ?`;
             return await handleListQuery(c,
                 `SELECT u.id as id, u.user_email, u.created_at, u.updated_at,`
                 + ` ur.role_text as role_text,`
                 + ` (SELECT COUNT(*) FROM users_address WHERE user_id = u.id) AS address_count`
                 + ` FROM users u`
                 + ` LEFT JOIN user_roles ur ON u.id = ur.user_id`
-                + ` where u.user_email like ?`,
-                `SELECT count(*) as count FROM users where user_email like ?`,
-                [`%${query}%`], limit, offset
+                + ` where ${userEmailWhere}`,
+                `SELECT count(*) as count FROM users where ${userEmailWhereCount}`,
+                [param], limit, offset
             );
         }
         return await handleListQuery(c,

--- a/worker/src/admin_api/index.ts
+++ b/worker/src/admin_api/index.ts
@@ -76,14 +76,19 @@ api.get('/admin/address', async (c) => {
     const sortDirection = sort_order === 'ascend' ? 'asc' : 'desc';
     const orderBy = `${sortColumn} ${sortDirection}`;
     if (query) {
+        // D1 caps LIKE pattern length at 50 bytes; fall back to instr() for
+        // longer queries to avoid "LIKE or GLOB pattern too complex" (#956).
+        const useInstr = new TextEncoder().encode(query).length + 2 > 50;
+        const whereClause = useInstr ? `instr(name, ?) > 0` : `name like ?`;
+        const param = useInstr ? query : `%${query}%`;
         return await handleListQuery(c,
             `SELECT a.*,`
             + ` (SELECT COUNT(*) FROM raw_mails WHERE address = a.name) AS mail_count,`
             + ` (SELECT COUNT(*) FROM sendbox WHERE address = a.name) AS send_count`
             + ` FROM address a`
-            + ` where name like ?`,
-            `SELECT count(*) as count FROM address where name like ?`,
-            [`%${query}%`], limit, offset, orderBy
+            + ` where ${whereClause}`,
+            `SELECT count(*) as count FROM address where ${whereClause}`,
+            [param], limit, offset, orderBy
         );
     }
     return await handleListQuery(c,


### PR DESCRIPTION
### **User description**
## Summary
- D1 caps LIKE/GLOB pattern length at **50 bytes** ([D1 limits](https://developers.cloudflare.com/d1/platform/limits/)). \`/admin/address\` and \`/admin/users\` wrap the query as \`%${query}%\` and feed it to LIKE, so searching by a full email address (e.g. \`a48r893s@5hx7zb.nationalgeographic.algomindtrade.com\`) crashes with \`D1_ERROR: LIKE or GLOB pattern too complex\`.
- Fall back to \`instr(name, ?) > 0\` when the wrapped pattern would exceed 50 bytes. Both branches are full scans (the original \`%query%\` LIKE never used the index either because of the leading wildcard), so there is no perf change.
- Short queries keep the original LIKE behaviour (case-insensitive); long queries use \`instr()\` which is case-sensitive — acceptable for the new path since address names are stored as-typed and admins search by exact value.

Fixes #956

## Test plan
- [ ] e2e: short query (subdomain fragment) still returns matching address via LIKE
- [ ] e2e: long full-email query (>50-byte pattern) returns 200 instead of D1 error
- [ ] e2e: same long-query regression check for \`/admin/users\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed D1 LIKE pattern length limit error in `/admin/address` and `/admin/users` queries by introducing a fallback to `instr()` for long queries.

- Added regression tests to ensure long queries (>50 bytes) do not crash and return expected results.

- Updated changelogs to document the fix for the D1 error and its implementation details.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  queryInput["Admin query input"]
  queryLengthCheck["Check query length"]
  fallbackInstr["Fallback to instr() for long queries"]
  executeQuery["Execute query"]
  queryInput -- "Input query" --> queryLengthCheck
  queryLengthCheck -- "Short query (<50 bytes)" --> executeQuery
  queryLengthCheck -- "Long query (>50 bytes)" --> fallbackInstr
  fallbackInstr -- "Use instr()" --> executeQuery
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin-address-query.spec.ts</strong><dd><code>Added regression tests for admin search queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/tests/api/admin-address-query.spec.ts

<ul><li>Added regression tests for short and long admin search queries.<br> <li> Verified long queries (>50 bytes) do not crash and return expected <br>results.<br> <li> Included tests for <code>/admin/address</code> and <code>/admin/users</code> endpoints.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/957/files#diff-8fe69448355da4188692ddba0a62f4538444133f1adf67f922d1f102f97f03ef">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin_user_api.ts</strong><dd><code>Fallback to `instr()` for long user queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/admin_api/admin_user_api.ts

<ul><li>Implemented fallback to <code>instr()</code> for long queries exceeding 50 bytes.<br> <li> Adjusted SQL query logic to handle both short and long queries.<br> <li> Prevented D1 LIKE pattern length error in <code>/admin/users</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/957/files#diff-2843fd3d54aa9aa8054d2530e84a06de3068c31fd5c7d5246db5d2a4234a6196">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Fallback to `instr()` for long address queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/admin_api/index.ts

<ul><li>Added fallback to <code>instr()</code> for long queries in <code>/admin/address</code>.<br> <li> Modified SQL query structure to handle D1 LIKE pattern length limit.<br> <li> Ensured compatibility with both short and long queries.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/957/files#diff-b470c4c47ce4a700cd8aac644d07d8a747d439bb6d69e9392a198b3a931fe2e7">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog with D1 error fix details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documented fix for D1 LIKE pattern length limit error.<br> <li> Explained fallback mechanism using <code>instr()</code> for long queries.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/957/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Updated English changelog with D1 error fix details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG_EN.md

<ul><li>Added English documentation for the D1 LIKE pattern length limit fix.<br> <li> Clarified fallback to <code>instr()</code> for long queries in admin endpoints.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/957/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复管理后台地址和用户查询页面在搜索超长邮箱条件时触发错误的问题，优化查询效率

* **文档**
  * 更新更新日志记录此次修复

* **测试**
  * 新增回归测试套件以验证长查询场景下的功能稳定性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->