### PR TITLE
feat(address): 支持最大地址数量设置为 0 表示无限制

### DIFF
--- a/frontend/src/views/admin/RoleAddressConfig.vue
+++ b/frontend/src/views/admin/RoleAddressConfig.vue
@@ -13,20 +13,20 @@ const { t } = useI18n({
     messages: {
         en: {
             role: 'Role',
-            maxAddressCount: 'Max Address Count',
+            maxAddressCount: 'Max Address Count (0 = Unlimited)',
             save: 'Save',
             successTip: 'Success',
             noRolesAvailable: 'No roles available in system config',
-            roleConfigDesc: 'Configure maximum address count for each user role. Role-based limits take priority over global settings.',
+            roleConfigDesc: 'Configure maximum address count for each user role. Role-based limits take priority over global settings. Set 0 for unlimited.',
             notConfigured: 'Not Configured (Use Global Settings)',
         },
         zh: {
             role: '角色',
-            maxAddressCount: '最大地址数量',
+            maxAddressCount: '最大地址数量（0 为不限制）',
             save: '保存',
             successTip: '成功',
             noRolesAvailable: '系统配置中没有可用的角色',
-            roleConfigDesc: '为每个用户角色配置最大地址数量。角色配置优先于全局设置。',
+            roleConfigDesc: '为每个用户角色配置最大地址数量。角色配置优先于全局设置。设置为 0 表示不限制。',
             notConfigured: '未配置（使用全局设置）',
         }
     }

--- a/frontend/src/views/admin/UserSettings.vue
+++ b/frontend/src/views/admin/UserSettings.vue
@@ -20,7 +20,7 @@ const { t } = useI18n({
             enableMailAllowList: 'Enable Mail Address Allow List(Manually enterable)',
             manualInputPrompt: 'Type and press Enter to add',
             mailAllowList: 'Mail Address Allow List',
-            maxAddressCount: 'Maximum number of email addresses that can be binded',
+            maxAddressCount: 'Maximum number of email addresses that can be binded (0 = Unlimited)',
             emailCheckRegex: "Email Check Regex (e.g. ^[^.]+{'@'}.+$ to disallow dots before {'@'})",
             enableEmailCheckRegex: 'Enable Email Check Regex',
         },
@@ -34,7 +34,7 @@ const { t } = useI18n({
             enableMailAllowList: '启用邮件地址白名单(可手动输入, 回车增加)',
             manualInputPrompt: '输入后按回车键添加',
             mailAllowList: '邮件地址白名单',
-            maxAddressCount: '可绑定最大邮箱地址数量',
+            maxAddressCount: '可绑定最大邮箱地址数量（0 为不限制）',
             emailCheckRegex: "邮箱正则校验 (例如 ^[^.]+{'@'}.+$ 禁止{'@'}前面有.)",
             enableEmailCheckRegex: '启用邮箱正则校验',
         }

--- a/worker/src/admin_api/admin_user_api.ts
+++ b/worker/src/admin_api/admin_user_api.ts
@@ -183,7 +183,10 @@ export default {
     saveRoleAddressConfig: async (c: Context<HonoCustomType>) => {
         const msgs = i18n.getMessagesbyContext(c);
         const { configs } = await c.req.json<{ configs: RoleAddressConfig }>();
-        for (const config of Object.values(configs || {})) {
+        if (typeof configs !== "object" || configs === null || Array.isArray(configs)) {
+            return c.text(msgs.InvalidMaxAddressCountMsg, 400);
+        }
+        for (const config of Object.values(configs)) {
             if (typeof config?.maxAddressCount === "number" && config.maxAddressCount < 0) {
                 return c.text(msgs.InvalidMaxAddressCountMsg, 400);
             }

--- a/worker/src/admin_api/admin_user_api.ts
+++ b/worker/src/admin_api/admin_user_api.ts
@@ -181,7 +181,13 @@ export default {
         return c.json({ configs });
     },
     saveRoleAddressConfig: async (c: Context<HonoCustomType>) => {
+        const msgs = i18n.getMessagesbyContext(c);
         const { configs } = await c.req.json<{ configs: RoleAddressConfig }>();
+        for (const config of Object.values(configs || {})) {
+            if (typeof config?.maxAddressCount === "number" && config.maxAddressCount < 0) {
+                return c.text(msgs.InvalidMaxAddressCountMsg, 400);
+            }
+        }
         await saveSetting(c, CONSTANTS.ROLE_ADDRESS_CONFIG_KEY, JSON.stringify(configs));
         return c.json({ success: true });
     },

--- a/worker/src/models/index.ts
+++ b/worker/src/models/index.ts
@@ -113,7 +113,7 @@ export class UserSettings {
         this.verifyMailSender = verifyMailSender;
         this.enableMailAllowList = enableMailAllowList;
         this.mailAllowList = mailAllowList;
-        this.maxAddressCount = maxAddressCount || 5;
+        this.maxAddressCount = typeof maxAddressCount === "number" ? maxAddressCount : 5;
         this.enableEmailCheckRegex = enableEmailCheckRegex;
         this.emailCheckRegex = emailCheckRegex;
     }

--- a/worker/src/models/index.ts
+++ b/worker/src/models/index.ts
@@ -113,7 +113,7 @@ export class UserSettings {
         this.verifyMailSender = verifyMailSender;
         this.enableMailAllowList = enableMailAllowList;
         this.mailAllowList = mailAllowList;
-        this.maxAddressCount = typeof maxAddressCount === "number" ? maxAddressCount : 5;
+        this.maxAddressCount = (typeof maxAddressCount === "number" && maxAddressCount >= 0) ? maxAddressCount : 5;
         this.enableEmailCheckRegex = enableEmailCheckRegex;
         this.emailCheckRegex = emailCheckRegex;
     }

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -365,8 +365,8 @@ export const getMaxAddressCount = async (
     const roleConfigs = await getJsonSetting<RoleAddressConfig>(c, CONSTANTS.ROLE_ADDRESS_CONFIG_KEY);
     if (!roleConfigs) return settings.maxAddressCount;
     const roleMaxCount = roleConfigs[userRole]?.maxAddressCount;
-		if (typeof roleMaxCount !== 'number') return settings.maxAddressCount;
-		if (roleMaxCount < 0) return settings.maxAddressCount;
+    if (typeof roleMaxCount !== 'number') return settings.maxAddressCount;
+    if (roleMaxCount < 0) return settings.maxAddressCount;
     return roleMaxCount;
 };
 

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -365,8 +365,8 @@ export const getMaxAddressCount = async (
     const roleConfigs = await getJsonSetting<RoleAddressConfig>(c, CONSTANTS.ROLE_ADDRESS_CONFIG_KEY);
     if (!roleConfigs) return settings.maxAddressCount;
     const roleMaxCount = roleConfigs[userRole]?.maxAddressCount;
-    if (typeof roleMaxCount !== 'number') return settings.maxAddressCount;
-    if (roleMaxCount <= 0) return settings.maxAddressCount;
+		if (typeof roleMaxCount !== 'number') return settings.maxAddressCount;
+		if (roleMaxCount < 0) return settings.maxAddressCount;
     return roleMaxCount;
 };
 


### PR DESCRIPTION
Close #966
## Summary

支持将角色（Role）的最大地址数量设置为 `0` 来表示无限制，解决此前 `0` 会被回退到全局设置的问题。

## Changes

### worker
- 移除 `utils.ts` 中 `=0` 回退到全局设置的逻辑(`<0` 仍然会回退)
- `models/index.ts` 中 0 视为无限制
- `admin_user_api.ts` 添加负数校验，防止无效输入

### frontend
- 更新页面文案，明确说明 0 表示无限制

## Test Plan

- [x] 将角色最大地址数设为 0，验证可创建超过默认配置数量的邮箱地址
- [x] 尝试设置负数，输入被阻止
- [x] 设为正整数时，验证正常限制生效

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档改进**
  * 更新界面文案，明确将地址计数为 0 表示“无限制 / 不限制”（中英双语）。

* **Bug 修复**
  * 修正默认值处理，保留数字 0 为有效值而非被覆盖。
  * 新增输入校验，拒绝负数的地址计数设置并返回错误提示。

* **功能改进**
  * 角色级别的地址计数限制现在可正确识别并生效（包括 0 表示无限制）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->