### PR TITLE
docs: add SEND_MAIL_DOMAINS docs

### DIFF
--- a/vitepress-docs/docs/en/guide/worker-vars.md
+++ b/vitepress-docs/docs/en/guide/worker-vars.md
@@ -39,6 +39,7 @@
 | `ENABLE_AUTO_REPLY`                   | Text/JSON | Allow automatic email replies. Sender filter (`source_prefix`) supports three modes: empty to match all senders, prefix for `startsWith` matching, or `/regex/` syntax for regex matching (e.g. `/@example\.com$/`) | `true`                                    |
 | `DEFAULT_SEND_BALANCE`                | Text/JSON | Default email sending balance, will be 0 if not set                                                                                                                                                               | `1`                                       |
 | `ENABLE_ADDRESS_PASSWORD`             | Text/JSON | Enable address password feature, when enabled, passwords will be auto-generated for new addresses, supports password login and modification                                                                       | `true`                                    |
+| `SEND_MAIL_DOMAINS`                   | JSON      | Restrict which sender domains can use the `SEND_MAIL` binding; when unset or empty, all domains are allowed                                                                                                     | `["example.com", "mail.example.com"]`     |
 
 > [!NOTE]
 > `RANDOM_SUBDOMAIN_DOMAINS` only controls automatic random subdomain generation during mailbox
@@ -58,6 +59,9 @@
 > The admin panel exposes three explicit states: **Follow Environment Variable**, **Force Enable**,
 > and **Force Disable**. Saving **Follow Environment Variable** clears the admin override and returns
 > the feature to the "unset" fallback behavior.
+>
+> `SEND_MAIL_DOMAINS` only affects the `SEND_MAIL` binding fallback path and
+> `/admin/send_mail_by_binding`. It does not affect Resend, SMTP, or `verifiedAddressList`.
 
 ## Email Reception Related Variables
 

--- a/vitepress-docs/docs/zh/guide/worker-vars.md
+++ b/vitepress-docs/docs/zh/guide/worker-vars.md
@@ -39,6 +39,7 @@
 | `ENABLE_AUTO_REPLY`                   | 文本/JSON | 允许自动回复邮件。发件人过滤（`source_prefix`）支持三种模式：留空匹配所有发件人、填写前缀进行 `startsWith` 匹配、使用 `/regex/` 语法进行正则匹配（如 `/@example\.com$/`） | `true`                                    |
 | `DEFAULT_SEND_BALANCE`                | 文本/JSON | 默认发送邮件余额，如果不设置，将为 0                                                                                              | `1`                                       |
 | `ENABLE_ADDRESS_PASSWORD`             | 文本/JSON | 启用邮箱地址密码功能，启用后创建新地址时会自动生成密码，并支持密码登录和修改                                                      | `true`                                    |
+| `SEND_MAIL_DOMAINS`                   | JSON      | 限制 `SEND_MAIL` binding 可用于哪些发件域名；留空或不配置时允许所有域名                                                            | `["example.com", "mail.example.com"]`     |
 
 > [!NOTE]
 > `RANDOM_SUBDOMAIN_DOMAINS` 只负责“创建地址时自动补随机子域名”，不会自动帮你创建 Cloudflare
@@ -54,6 +55,9 @@
 >
 > 管理后台提供三种显式状态：**跟随环境变量**、**强制开启**、**强制关闭**。当你选择
 > “跟随环境变量”并保存时，会清空后台覆盖，恢复到“未设置”的回退行为。
+>
+> `SEND_MAIL_DOMAINS` 只影响 `SEND_MAIL` binding 的兜底发信路径和 `/admin/send_mail_by_binding`。
+> 它不影响 Resend、SMTP、`verifiedAddressList` 等其他发信通道。
 
 ## 接受邮件相关变量
 

--- a/worker/wrangler.toml.template
+++ b/worker/wrangler.toml.template
@@ -21,6 +21,7 @@ keep_vars = true
 # send_email = [
 #    { name = "SEND_MAIL" },
 # ]
+# SEND_MAIL_DOMAINS = ["example.com", "mail.example.com"]
 
 [vars]
 # DEFAULT_LANG = "zh"


### PR DESCRIPTION
### **User description**
## Summary
- add SEND_MAIL_DOMAINS example to the wrangler template
- document SEND_MAIL_DOMAINS in Chinese and English worker variable docs
- clarify that it only affects SEND_MAIL binding fallback and /admin/send_mail_by_binding

## Testing
- not run (docs only)


___

### **PR Type**
Documentation


___

### **Description**
- Added documentation for `SEND_MAIL_DOMAINS` variable in English and Chinese guides.

- Clarified the scope and behavior of `SEND_MAIL_DOMAINS` in fallback paths and admin panel.

- Included an example of `SEND_MAIL_DOMAINS` in the `wrangler.toml.template` file.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SEND_MAIL_DOMAINS_DOCS["Document SEND_MAIL_DOMAINS variable"] -- "English guide update" --> EN_GUIDE
  SEND_MAIL_DOMAINS_DOCS -- "Chinese guide update" --> ZH_GUIDE
  SEND_MAIL_DOMAINS_DOCS -- "Example in wrangler.toml.template" --> WRANGLER_TEMPLATE
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker-vars.md</strong><dd><code>Document `SEND_MAIL_DOMAINS` variable in English guide</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vitepress-docs/docs/en/guide/worker-vars.md

<ul><li>Added <code>SEND_MAIL_DOMAINS</code> variable documentation.<br> <li> Clarified its scope and fallback behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/988/files#diff-fb5fa2149e9d484384eaac2520f95441eacbacf83f8451049459695ef22d0b8b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worker-vars.md</strong><dd><code>Document `SEND_MAIL_DOMAINS` variable in Chinese guide</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vitepress-docs/docs/zh/guide/worker-vars.md

<ul><li>Added <code>SEND_MAIL_DOMAINS</code> variable documentation in Chinese.<br> <li> Clarified its scope and fallback behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/988/files#diff-1bd83b534dfb9159de9157e0943a1f5191373ecdb5af08552c8033464596d223">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wrangler.toml.template</strong><dd><code>Add example for `SEND_MAIL_DOMAINS` in wrangler template</code>&nbsp; </dd></summary>
<hr>

worker/wrangler.toml.template

- Added an example configuration for `SEND_MAIL_DOMAINS`.


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/988/files#diff-743273da72481b71fbeb1dddfd294be9249554eef65691dfc9bcfa9f0fd971fb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 添加新的环境变量 `SEND_MAIL_DOMAINS`，用于限制允许使用邮件发送功能的域名。空置或未设置时默认允许所有域名。新增配置说明和使用示例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->