### PR TITLE
fix: 修复前端设置初始化时未返回 domains 数组导致的 undefined 错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| 修复 `/open_api/settings` 未返回 `domains` 数组时前端设置初始化直接调用 `map()` 报 `undefined` 错误的问题，统一按空数组兜底处理
+
 ### Improvements
 
 - refactor: |Worker| 拆分 `mails_api/index.ts` 与 `admin_api/index.ts`，入口只负责挂路由，业务拆到各自的 `*_api.ts` 文件（`mails_crud.ts` / `new_address.ts` / `parsed_mail_api.ts` / `address_api.ts` / `address_sender_api.ts` / `sendbox_api.ts` / `statistics_api.ts` / `account_settings_api.ts`），保持路径与行为不变

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -16,6 +16,8 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| Fix the frontend settings bootstrap throwing an `undefined` error when `/open_api/settings` does not return a `domains` array by normalizing the field to an empty array before mapping it
+
 ### Improvements
 
 - refactor: |Worker| Split `mails_api/index.ts` and `admin_api/index.ts` so the index files only wire routes. Business logic moved into dedicated `*_api.ts` files (`mails_crud.ts` / `new_address.ts` / `parsed_mail_api.ts` / `address_api.ts` / `address_sender_api.ts` / `sendbox_api.ts` / `statistics_api.ts` / `account_settings_api.ts`). Paths and behavior unchanged

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -62,8 +62,9 @@ const apiFetch = async (path, options = {}) => {
 const getOpenSettings = async (message, notification) => {
     try {
         const res = await api.fetch("/open_api/settings");
+        const domains = Array.isArray(res["domains"]) ? res["domains"] : [];
         const domainLabels = res["domainLabels"] || [];
-        if (res["domains"]?.length < 1) {
+        if (domains.length < 1) {
             message.error("No domains found, please check your worker settings");
         }
         Object.assign(openSettings.value, {
@@ -75,7 +76,7 @@ const getOpenSettings = async (message, notification) => {
             needAuth: res["needAuth"] || false,
             defaultDomains: res["defaultDomains"] || [],
             randomSubdomainDomains: res["randomSubdomainDomains"] || [],
-            domains: res["domains"].map((domain, index) => {
+            domains: domains.map((domain, index) => {
                 return {
                     label: domainLabels.length > index ? domainLabels[index] : domain,
                     value: domain


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * 修复了系统设置接口在未返回域名数据时导致前端初始化失败的问题

<!-- end of auto-generated comment: release notes by coderabbit.ai -->