### PR TITLE
fix: constrain address management modal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| 收窄地址管理相关弹窗宽度，并让地址表格在弹窗内部横向滚动，避免多地址场景撑宽弹窗
 - fix: |Frontend| 修复 `/open_api/settings` 未返回 `domains` 数组时前端设置初始化直接调用 `map()` 报 `undefined` 错误的问题，统一按空数组兜底处理
 
 ### Improvements

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| Narrow address-management modal widths and keep address tables horizontally scrollable inside the modal to prevent multi-address lists from stretching the dialog
 - fix: |Frontend| Fix the frontend settings bootstrap throwing an `undefined` error when `/open_api/settings` does not return a `domains` array by normalizing the field to an empty array before mapping it
 
 ### Improvements

--- a/frontend/src/views/admin/UserAddressManagement.vue
+++ b/frontend/src/views/admin/UserAddressManagement.vue
@@ -67,13 +67,18 @@ onMounted(async () => {
 </script>
 
 <template>
-    <div style="overflow: auto;">
+    <div class="address-table-scroll">
         <n-data-table :columns="columns" :data="data" :bordered="false" embedded />
     </div>
 </template>
 
 <style scoped>
 .n-data-table {
-    min-width: 700px;
+    min-width: 640px;
+}
+
+.address-table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
 }
 </style>

--- a/frontend/src/views/admin/UserManagement.vue
+++ b/frontend/src/views/admin/UserManagement.vue
@@ -344,7 +344,8 @@ onMounted(async () => {
                 </n-button>
             </template>
         </n-modal>
-        <n-modal v-model:show="showUserAddressManagement" preset="card" :title="t('userAddressManagement')">
+        <n-modal v-model:show="showUserAddressManagement" preset="card" :title="t('userAddressManagement')"
+            style="width: 720px;">
             <UserAddressManagement :user_id="curUserId" />
         </n-modal>
         <n-input-group>

--- a/frontend/src/views/index/AddressBar.vue
+++ b/frontend/src/views/index/AddressBar.vue
@@ -99,7 +99,8 @@ onMounted(async () => {
                 </n-collapse>
             </n-card>
         </n-modal>
-        <n-modal v-model:show="showAddressManage" preset="card" :title="t('addressManage')">
+        <n-modal v-model:show="showAddressManage" preset="card" :title="t('addressManage')"
+            style="width: 720px;">
             <TelegramAddress v-if="isTelegram" />
             <AddressManagement v-else-if="userJwt" />
             <LocalAddress v-else />
@@ -130,4 +131,5 @@ onMounted(async () => {
     flex: 0 0 auto;
     white-space: nowrap;
 }
+
 </style>

--- a/frontend/src/views/index/LocalAddress.vue
+++ b/frontend/src/views/index/LocalAddress.vue
@@ -138,6 +138,10 @@ const columns = [
 </template>
 
 <style scoped>
+.n-data-table {
+    min-width: 640px;
+}
+
 .address-table-scroll {
     max-width: 100%;
     overflow-x: auto;

--- a/frontend/src/views/index/LocalAddress.vue
+++ b/frontend/src/views/index/LocalAddress.vue
@@ -126,7 +126,9 @@ const columns = [
         </n-alert>
         <n-tabs type="segment" v-model:value="tabValue">
             <n-tab-pane name="address" :tab="t('address')">
-                <n-data-table :columns="columns" :data="data" :bordered="false" embedded />
+                <div class="address-table-scroll">
+                    <n-data-table :columns="columns" :data="data" :bordered="false" embedded />
+                </div>
             </n-tab-pane>
             <n-tab-pane name="create_or_bind" :tab="t('create_or_bind')">
                 <Login :bindUserAddress="bindAddress" />
@@ -134,3 +136,10 @@ const columns = [
         </n-tabs>
     </div>
 </template>
+
+<style scoped>
+.address-table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+}
+</style>

--- a/frontend/src/views/index/TelegramAddress.vue
+++ b/frontend/src/views/index/TelegramAddress.vue
@@ -145,6 +145,10 @@ onMounted(async () => {
 </template>
 
 <style scoped>
+.n-data-table {
+    min-width: 640px;
+}
+
 .address-table-scroll {
     max-width: 100%;
     overflow-x: auto;

--- a/frontend/src/views/index/TelegramAddress.vue
+++ b/frontend/src/views/index/TelegramAddress.vue
@@ -133,7 +133,9 @@ onMounted(async () => {
     <div>
         <n-tabs type="segment">
             <n-tab-pane name="address" :tab="t('address')">
-                <n-data-table :columns="columns" :data="data" :bordered="false" embedded />
+                <div class="address-table-scroll">
+                    <n-data-table :columns="columns" :data="data" :bordered="false" embedded />
+                </div>
             </n-tab-pane>
             <n-tab-pane name="bind" :tab="t('bind')">
                 <Login :newAddressPath="newAddressPath" :bindUserAddress="bindAddress" />
@@ -141,3 +143,10 @@ onMounted(async () => {
         </n-tabs>
     </div>
 </template>
+
+<style scoped>
+.address-table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+}
+</style>

--- a/frontend/src/views/user/AddressManagement.vue
+++ b/frontend/src/views/user/AddressManagement.vue
@@ -196,7 +196,7 @@ onMounted(async () => {
         </n-modal>
         <n-tabs type="segment">
             <n-tab-pane name="address" :tab="t('address')">
-                <div style="overflow: auto;">
+                <div class="address-table-scroll">
                     <n-data-table :columns="columns" :data="data" :bordered="false" embedded />
                 </div>
             </n-tab-pane>
@@ -209,6 +209,11 @@ onMounted(async () => {
 
 <style scoped>
 .n-data-table {
-    min-width: 700px;
+    min-width: 640px;
+}
+
+.address-table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
 }
 </style>


### PR DESCRIPTION
## Summary
- constrain address-management modal width on index and admin user pages
- keep address-management tables horizontally scrollable inside their containers
- update Chinese and English changelogs

## Tests
- pnpm test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化地址管理界面：将地址管理弹窗宽度固定为更合适的尺寸，并在弹窗内的地址表格区域启用水平滚动与宽度约束，避免在存在多条地址时弹窗被过度拉伸，改善窄屏或多列数据下的显示与可用性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->