### PR TITLE
docs: 添加 CloudMail 移动端管理客户端

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 - [x] 支持 `CF Turnstile` 人机验证
 - [x] 限流配置，防止滥用
 - [x] **Agent 友好**：内置 [`cf-temp-mail-agent-mail`](skills/cf-temp-mail-agent-mail/SKILL.md) skill，AI agent 可直接消费邮箱，详见 [文档](vitepress-docs/docs/zh/guide/feature/agent-email.md)
+- [x] 社区移动端管理客户端：[CloudMail](https://github.com/Lur1N77777/CloudMail) 基于 Expo / React Native，面向本项目兼容 API，提供 Android 管理员后台、地址管理、收件/发件/未知邮件、验证码快捷复制、OLED 黑主题和本地分组。
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -151,6 +151,7 @@ Try it now → [https://mail.awsl.uk/](https://mail.awsl.uk/)
 - [x] Support `CF Turnstile` CAPTCHA verification
 - [x] Rate limiting configuration to prevent abuse
 - [x] **Agent-friendly**: bundled [`cf-temp-mail-agent-mail`](skills/cf-temp-mail-agent-mail/SKILL.md) skill lets AI agents consume a mailbox directly, see [docs](vitepress-docs/docs/en/guide/feature/agent-email.md)
+- [x] Community mobile admin client: [CloudMail](https://github.com/Lur1N77777/CloudMail) is built with Expo / React Native for this project's compatible API, providing an Android admin console, address management, inbox/sent/unknown mail, quick verification-code copy, OLED black theme, and local grouping.
 
 </details>
 


### PR DESCRIPTION
你好，感谢维护这个项目。

按之前回复里提到的建议，这个 PR 把 CloudMail 添加到 README 的“集成与扩展”部分，作为一个面向 `cloudflare_temp_email` 兼容 API 的社区移动端管理员客户端。

CloudMail 是基于 Expo / React Native 开发的 Android 客户端，主要面向手机端管理员工作流，支持：

- 管理员后台
- 地址管理
- 收件 / 发件 / 未知邮件查看
- 验证码快捷复制
- OLED 黑主题
- 本地分组筛选

本 PR 只修改 README 文档，不包含代码改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 在集成与扩展部分更新清单，新增社区移动管理员客户端项目条目，包含项目链接及其提供的移动管理功能、邮件管理能力和UI主题定制等详细信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->