### PR TITLE
fix: improve mobile header menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fix: |Frontend| 收窄地址管理相关弹窗宽度，并让地址表格在弹窗内部横向滚动，避免多地址场景撑宽弹窗
 - fix: |Frontend| 修复 `/open_api/settings` 未返回 `domains` 数组时前端设置初始化直接调用 `map()` 报 `undefined` 错误的问题，统一按空数组兜底处理
 - fix: |Frontend| 修复前端在 `jwt` / `auth` / `adminAuth` 等 localStorage 凭据为空字符串、字面量 `"undefined"` 或包含换行/控制符时，请求构造的 `Authorization` 等头部抛出 `Invalid character in header content` 导致前端所有接口报错的问题（issue #1000）。新增 `safeHeaderValue` / `safeBearerHeader` 工具，对全部认证头做 RFC 7230 校验，不安全的值直接跳过该头部，让 worker 走标准 401 而不是请求级崩溃
+- fix: |Frontend| 修复多语言菜单在移动端顶部显示语言与版本按钮导致 Header 横向拥挤或溢出的问题，移动端仅保留菜单按钮并将语言/版本入口放入抽屉
 
 ### Improvements
 

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -24,6 +24,7 @@
 - fix: |Frontend| Narrow address-management modal widths and keep address tables horizontally scrollable inside the modal to prevent multi-address lists from stretching the dialog
 - fix: |Frontend| Fix the frontend settings bootstrap throwing an `undefined` error when `/open_api/settings` does not return a `domains` array by normalizing the field to an empty array before mapping it
 - fix: |Frontend| Fix every API call crashing client-side with `Invalid character in header content ["Authorization"]` when stale localStorage credentials (`jwt` / `auth` / `adminAuth` / `userJwt` / `access_token`) are empty, the literal string `"undefined"`, or contain a stray newline or other control character (issue #1000). Adds `safeHeaderValue` / `safeBearerHeader` helpers that validate every auth header against RFC 7230 and omit the header entirely when unsafe, so the worker returns a clean 401 instead of the request being rejected by axios/undici
+- fix: |Frontend| Fix the multilingual header on mobile by keeping only the menu button in the top bar and moving language/version actions into the drawer to avoid horizontal crowding or overflow
 
 ### Improvements
 

--- a/frontend/src/views/Header.vue
+++ b/frontend/src/views/Header.vue
@@ -7,7 +7,7 @@ import { useIsMobile } from '../utils/composables'
 import {
     DarkModeFilled, LightModeFilled, MenuFilled,
     AdminPanelSettingsFilled, MonitorHeartFilled,
-    KeyboardArrowDownOutlined
+    KeyboardArrowDownOutlined, OpenInNewOutlined
 } from '@vicons/material'
 import { GithubAlt, Language, User, Home } from '@vicons/fa'
 
@@ -254,13 +254,13 @@ onMounted(async () => {
             <template #extra>
                 <n-space align="center" class="header-extra">
                     <n-menu v-if="!isMobile" mode="horizontal" :options="menuOptions" responsive />
-                    <n-button v-else :text="true" @click="showMobileMenu = !showMobileMenu" style="margin-right: 10px;">
+                    <n-button v-else :text="true" @click="showMobileMenu = !showMobileMenu">
                         <template #icon>
                             <n-icon :component="MenuFilled" />
                         </template>
                         {{ t('menu') }}
                     </n-button>
-                    <n-dropdown :options="languageOptions" @select="changeLocale" trigger="click" class="header-locale-dropdown">
+                    <n-dropdown v-if="!isMobile" :options="languageOptions" @select="changeLocale" trigger="click" class="header-locale-dropdown">
                         <n-button text size="small" class="header-locale-button" style="padding: 0 10px;">
                             <template #icon>
                                 <n-icon :component="Language" />
@@ -270,7 +270,7 @@ onMounted(async () => {
                         </n-button>
                     </n-dropdown>
                     <n-button
-                        v-if="openSettings.showGithub"
+                        v-if="!isMobile && openSettings.showGithub"
                         text
                         size="small"
                         class="header-version-button"
@@ -289,29 +289,26 @@ onMounted(async () => {
         <n-drawer v-model:show="showMobileMenu" placement="top" style="height: 100vh;">
             <n-drawer-content :title="t('menu')" closable>
                 <n-menu :options="menuOptions" />
-                <n-dropdown :options="languageOptions" @select="changeLocale" trigger="click" class="header-locale-dropdown">
-                    <n-button text class="header-locale-button" style="margin-top: 12px;">
-                        <template #icon>
+                <div class="mobile-menu-actions">
+                    <n-dropdown :options="languageOptions" @select="changeLocale" trigger="click" class="header-locale-dropdown">
+                        <button type="button" class="mobile-menu-utility-button">
                             <n-icon :component="Language" />
-                        </template>
-                        {{ currentLocaleLabel }}
-                        <n-icon :component="KeyboardArrowDownOutlined" style="margin-left: 4px;" />
-                    </n-button>
-                </n-dropdown>
-                <n-button
-                    v-if="openSettings.showGithub"
-                    text
-                    class="header-version-button"
-                    style="margin-top: 12px;"
-                    tag="a"
-                    target="_blank"
-                    href="https://github.com/dreamhunter2333/cloudflare_temp_email"
-                >
-                    <template #icon>
+                            <span class="mobile-menu-action-label">{{ currentLocaleLabel }}</span>
+                            <n-icon :component="KeyboardArrowDownOutlined" class="mobile-menu-action-arrow" />
+                        </button>
+                    </n-dropdown>
+                    <a
+                        v-if="openSettings.showGithub"
+                        class="mobile-menu-utility-button"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://github.com/dreamhunter2333/cloudflare_temp_email"
+                    >
                         <n-icon :component="GithubAlt" />
-                    </template>
-                    {{ version || 'Github' }}
-                </n-button>
+                        <span class="mobile-menu-action-label">{{ version || 'Github' }}</span>
+                        <n-icon :component="OpenInNewOutlined" class="mobile-menu-action-arrow" />
+                    </a>
+                </div>
             </n-drawer-content>
         </n-drawer>
         <n-modal v-model:show="showAuth" :closable="false" :closeOnEsc="false" :maskClosable="false" preset="dialog"
@@ -337,6 +334,7 @@ onMounted(async () => {
 
 .header-extra {
     align-items: center;
+    flex-wrap: nowrap;
 }
 
 .header-extra :deep(.n-space-item) {
@@ -369,6 +367,46 @@ onMounted(async () => {
     align-items: center;
 }
 
+.mobile-menu-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(128, 128, 128, 0.16);
+}
+
+.mobile-menu-utility-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    width: 100%;
+    min-width: 0;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: none;
+    opacity: 0.82;
+    cursor: pointer;
+}
+
+.mobile-menu-action-label {
+    margin: 0 6px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mobile-menu-action-arrow {
+    flex: 0 0 auto;
+    margin-left: 2px;
+}
+
 .n-alert {
     margin-top: 10px;
     margin-bottom: 10px;
@@ -389,5 +427,18 @@ onMounted(async () => {
 
 .n-form .n-button {
     margin-top: 10px;
+}
+
+@media (max-width: 640px) {
+    :deep(.n-page-header__title) {
+        min-width: 0;
+    }
+
+    :deep(.n-page-header__title h3) {
+        max-width: calc(100vw - 136px);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
 </style>


### PR DESCRIPTION
### **User description**
## Summary
- keep language and version actions out of the mobile top header to prevent crowding
- add compact language/version actions at the bottom of the mobile drawer
- preserve existing main drawer menu behavior and icons
- update zh/en changelog entries

## Testing
- `pnpm build` in `frontend`
- `git diff --check`
- checked 390px/320px mobile viewport in browser


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Prevent mobile header locale/version crowding

- Show locale/version controls inside drawer

- Add mobile-only utility button styling

- Update zh/en changelog entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TopHeader["Header top bar"] -- "desktop shows language/version" --> DesktopActions["Desktop language/version controls"]
  TopHeader -- "mobile keeps only menu button" --> MobileDrawer["Mobile drawer (top)"]
  MobileDrawer -- "renders locale + version actions" --> UtilityButtons["Drawer utility buttons"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Header.vue</strong><dd><code>Move mobile header locale/version actions into drawer</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/Header.vue

<ul><li>Hide locale dropdown and version link on mobile<br> <li> Add drawer footer actions: locale + GitHub link<br> <li> Introduce mobile utility button + grid CSS<br> <li> Add small-screen title ellipsis styling</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1016/files#diff-a80b3d70a6be259910c988c05d497228b10a5e686042743c1831584fb391360d">+76/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document multilingual mobile header change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add frontend entry for mobile header fix


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1016/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Document multilingual mobile header change (EN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG_EN.md

- Add English entry for mobile header fix


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1016/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化移动端头部显示：调整了多语言菜单的响应式布局。顶部菜单栏现仅保留菜单按钮，原有的语言和版本选项已移至抽屉菜单中，有效防止了移动设备屏幕上的界面拥挤和溢出问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->