### PR TITLE
docs: fix typo in title from 'Gihub' to 'GitHub'

### DIFF
--- a/vitepress-docs/docs/zh/guide/actions/pre-requisite.md
+++ b/vitepress-docs/docs/zh/guide/actions/pre-requisite.md
@@ -1,4 +1,4 @@
-# Gihub Actions 部署准备
+# GitHub Actions 部署准备
 
 ## GitHub 账户
 


### PR DESCRIPTION
This pull request corrects a small typo in the documentation by fixing the heading for the GitHub Actions deployment prerequisites guide. No other changes were made.

- Fixed a typo in the heading from "Gihub Actions" to "GitHub Actions" in `vitepress-docs/docs/zh/guide/actions/pre-requisite.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 修正了指南文档中的拼写错误，改进了文档的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->