### PR TITLE
ci: allow docs deploy without GitHub release

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -44,7 +44,12 @@ jobs:
           cd vitepress-docs/
           wget https://github.com/dreamhunter2333/cloudflare_temp_email/releases/latest/download/frontend.zip -O docs/public/ui_install/frontend.zip
           pnpm install --no-frozen-lockfile
-          TAG_NAME=$(gh release view --json tagName --jq '.tagName')
+          if TAG_NAME=$(gh release view --json tagName --jq '.tagName' 2>/dev/null); then
+            echo "Using release tag $TAG_NAME"
+          else
+            TAG_NAME="${GITHUB_REF_NAME:-main}"
+            echo "No GitHub release found for this repo; fallback TAG_NAME=$TAG_NAME"
+          fi
           echo "Deploying docs for tag $TAG_NAME"
           export TAG_NAME
           pnpm run deploy

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -40,6 +40,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           cd vitepress-docs/
           wget https://github.com/dreamhunter2333/cloudflare_temp_email/releases/latest/download/frontend.zip -O docs/public/ui_install/frontend.zip
@@ -47,7 +48,7 @@ jobs:
           if TAG_NAME=$(gh release view --json tagName --jq '.tagName' 2>/dev/null); then
             echo "Using release tag $TAG_NAME"
           else
-            TAG_NAME="${GITHUB_REF_NAME:-main}"
+            TAG_NAME="${WORKFLOW_RUN_HEAD_BRANCH:-${GITHUB_REF_NAME:-main}}"
             echo "No GitHub release found for this repo; fallback TAG_NAME=$TAG_NAME"
           fi
           echo "Deploying docs for tag $TAG_NAME"


### PR DESCRIPTION
## Summary
- make `Deploy Docs` work on forks without GitHub Releases
- keep using the release tag when available
- fall back to `GITHUB_REF_NAME` (for example `main`) when `gh release view` returns no release

## Why
The current docs workflow fails on forks when triggered manually because it assumes the repository has a GitHub Release and aborts with `release not found`. This small fallback keeps the original release-based behavior for upstream while making fork-based manual docs deployment work.

## Validation
- reproduced the failure on a fork with `release not found`
- applied this fallback change
- re-ran `Deploy Docs` on the fork successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **杂项工作**
  * 优化了文档部署流程：确保发布标签在部署前始终可用，增加多重回退机制以处理查询失败，避免因未处理的标签查找失败而中断部署，提升部署稳定性和容错能力。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dreamhunter2333/cloudflare_temp_email/pull/1023)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->