### PR TITLE
fix(telegram): surface verification codes in mail previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- fix: |Telegram| 邮件推送支持从 HTML 正文回退提取文本，并优先识别 4-8 位验证码，兼容空格、连字符、HTML entity 等常见格式，避免验证码邮件只显示“解析失败，请打开 mini app 查看”
 - fix: |Admin| 管理员重置邮箱地址密码时改为前端 SHA-256 后提交，后端只接受并存储哈希值，避免该接口继续接收明文密码
 - fix: |Address| 管理员邮箱地址列表与用户绑定地址列表不再返回已存储的地址密码哈希值，避免列表接口暴露敏感字段
 - fix: |AI 提取| 将 AI 邮件识别默认 Workers AI 模型切换为支持 JSON Mode 且未弃用的 `@cf/meta/llama-3.1-8b-instruct-fast`，并在文档中补充 `@cf/zai-org/glm-4.7-flash` 结构化输出兼容性提示（issue #1029）

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- fix: |Telegram| Support falling back from HTML mail bodies to plain text in Telegram push messages, and surface 4-8 digit verification codes first, including common formats with spaces, separators, and HTML entities, instead of only showing “please open the mini app”
 - fix: |Admin| Hash address passwords in the frontend before admin reset requests, and make the backend accept and store only the hash instead of plaintext
 - fix: |Address| Stop returning stored address password hashes from the admin address list and user bound-address list APIs to avoid exposing sensitive fields
 - fix: |AI Extract| Switch the default Workers AI model for AI email recognition to the JSON Mode-compatible, non-deprecated `@cf/meta/llama-3.1-8b-instruct-fast`, and document structured-output compatibility guidance for `@cf/zai-org/glm-4.7-flash` (issue #1029)

--- a/pages/wrangler.toml
+++ b/pages/wrangler.toml
@@ -1,4 +1,4 @@
-name = "temp-email-pages"
+name = "cloudflare-temp-email-pages"
 pages_build_output_dir = "../frontend/dist"
 compatibility_date = "2024-05-13"
 

--- a/worker/src/telegram_api/telegram.ts
+++ b/worker/src/telegram_api/telegram.ts
@@ -14,6 +14,7 @@ import { RawMailRow } from "../models";
 import { UserFromGetMe } from "telegraf/types";
 import i18n from "../i18n";
 import { LocaleMessages } from "../i18n/type";
+import { buildSearchableMailText, extractVerificationCode, htmlToPlainText } from "./verification_code";
 
 
 // Helper to get messages by userId
@@ -388,17 +389,24 @@ const parseMail = async (
     }
     try {
         const parsedEmail = await commonParseMail(parsedEmailContext);
-        let parsedText = parsedEmail?.text || "";
+        const htmlText = parsedEmail?.html ? htmlToPlainText(parsedEmail.html) : "";
+        let parsedText = parsedEmail?.text || htmlText;
+        const verificationCode = extractVerificationCode(
+            buildSearchableMailText(parsedEmail?.subject, parsedEmail?.text, parsedEmail?.html)
+        );
         if (parsedText.length && parsedText.length > 1000) {
-            parsedText = parsedEmail?.text.substring(0, 1000) + `\n\n...\n${msgs.TgMsgTooLongMsg}`;
+            parsedText = parsedText.substring(0, 1000) + `\n\n...\n${msgs.TgMsgTooLongMsg}`;
         }
+        const content = verificationCode
+            ? `验证码：${verificationCode}` + (parsedText ? `\n\n${parsedText}` : "")
+            : (parsedText || msgs.TgParseFailedViewInAppMsg);
         return {
             isHtml: false,
             mail: `From: ${parsedEmail?.sender || msgs.TgNoSenderMsg}\n`
                 + `To: ${address}\n`
                 + (created_at ? `Date: ${created_at}\n` : "")
                 + `Subject: ${parsedEmail?.subject}\n`
-                + `Content:\n${parsedText || msgs.TgParseFailedViewInAppMsg}`
+                + `Content:\n${content}`
         };
     } catch (e) {
         return {

--- a/worker/src/telegram_api/verification_code.test.ts
+++ b/worker/src/telegram_api/verification_code.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { buildSearchableMailText, extractVerificationCode, htmlToPlainText } from "./verification_code.ts";
+
+describe("verification code extraction", () => {
+    it("extracts a ChatGPT code from HTML-only mail", () => {
+        const html = `<html><body><p>Your temporary ChatGPT login code is:</p><div style="font-size:32px">123456</div><p>This code expires in 10 minutes.</p></body></html>`;
+        const body = buildSearchableMailText("Your temporary ChatGPT login code", "", html);
+
+        assert.equal(extractVerificationCode(body), "123456");
+    });
+
+    it("extracts spaced and separated numeric codes", () => {
+        const text = "您的验证码为 1 2 3-4_5.6，请勿泄露。";
+
+        assert.equal(extractVerificationCode(text), "123456");
+    });
+
+    it("supports 4 and 8 digit verification codes", () => {
+        assert.equal(extractVerificationCode("Login PIN: 0428. It expires soon."), "0428");
+        assert.equal(extractVerificationCode("安全验证码：87654321，5分钟内有效"), "87654321");
+    });
+
+    it("prefers code-related context over unrelated numbers", () => {
+        const text = "订单 987654 于 2026-05-04 创建。验证码是 135790，请在 10 分钟内输入。";
+
+        assert.equal(extractVerificationCode(text), "135790");
+    });
+
+    it("converts HTML entities and basic tags to readable text", () => {
+        const html = "<div>验证码：&#49;&#50;&#51;&#52;&#53;&#54;</div><br><span>请勿泄露&nbsp;code</span>";
+
+        assert.match(htmlToPlainText(html), /验证码：123456/);
+        assert.match(htmlToPlainText(html), /请勿泄露 code/);
+    });
+});

--- a/worker/src/telegram_api/verification_code.ts
+++ b/worker/src/telegram_api/verification_code.ts
@@ -1,0 +1,141 @@
+const MAX_CODE_CONTEXT_LENGTH = 120;
+
+const htmlEntityMap: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+    ensp: " ",
+    emsp: " ",
+    thinsp: " ",
+    zwnj: "",
+    zwj: "",
+};
+
+export const decodeHtmlEntities = (value: string): string => {
+    return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]+);/g, (entity, code: string) => {
+        const lowerCode = code.toLowerCase();
+        if (lowerCode.startsWith("#x")) {
+            const charCode = parseInt(lowerCode.slice(2), 16);
+            return Number.isFinite(charCode) ? String.fromCodePoint(charCode) : entity;
+        }
+        if (lowerCode.startsWith("#")) {
+            const charCode = parseInt(lowerCode.slice(1), 10);
+            return Number.isFinite(charCode) ? String.fromCodePoint(charCode) : entity;
+        }
+        return htmlEntityMap[lowerCode] ?? entity;
+    });
+};
+
+export const htmlToPlainText = (html: string): string => {
+    return decodeHtmlEntities(html)
+        .replace(/<\s*(script|style)[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, " ")
+        .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+        .replace(/<\s*\/\s*(p|div|tr|td|th|li|h[1-6]|table|section|article)\s*>/gi, "\n")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/[\u200B-\u200D\uFEFF]/g, "")
+        .replace(/[ \t\r\f\v]+/g, " ")
+        .replace(/\n\s+/g, "\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .trim();
+};
+
+export const buildSearchableMailText = (subject?: string, text?: string, html?: string): string => {
+    return [subject || "", text || "", html ? htmlToPlainText(html) : ""]
+        .filter(part => part.trim().length > 0)
+        .join("\n");
+};
+
+const compactCandidateCode = (value: string): string => {
+    return value.replace(/[\s\-_.:：]/g, "");
+};
+
+const isLikelyDateOrTime = (code: string, context: string): boolean => {
+    if (/^(19|20)\d{2}$/.test(code)) {
+        return true;
+    }
+    if (/^\d{8}$/.test(code) && /(?:date|日期|时间|time|expires?|过期|有效期)/i.test(context)) {
+        return true;
+    }
+    if (/^\d{4}$/.test(code) && /[:：]\s*\d{2}/.test(context)) {
+        return true;
+    }
+    return false;
+};
+
+const distanceToNearestKeyword = (context: string, codeStartInContext: number): number => {
+    const keywordPattern = /(verification|verify|login|sign.?in|security|auth|authentication|one.?time|otp|passcode|code|pin|temporary|确认|验证|验证码|校验码|动态码|登录|登入|安全|口令|一次性|临时)/ig;
+    let nearest = Number.POSITIVE_INFINITY;
+    let match: RegExpExecArray | null;
+    while ((match = keywordPattern.exec(context)) !== null) {
+        const keywordStart = match.index;
+        const keywordEnd = match.index + match[0].length;
+        const distance = codeStartInContext < keywordStart
+            ? keywordStart - codeStartInContext
+            : Math.max(0, codeStartInContext - keywordEnd);
+        nearest = Math.min(nearest, distance);
+    }
+    return nearest;
+};
+
+const scoreCandidate = (code: string, context: string, index: number, codeStartInContext: number): number => {
+    let score = 0;
+
+    if (code.length === 6) score += 30;
+    if (code.length === 8) score += 20;
+    if (code.length === 4) score += 10;
+    if (code.length >= 5 && code.length <= 8) score += 10;
+
+    const keywordDistance = distanceToNearestKeyword(context, codeStartInContext);
+    if (Number.isFinite(keywordDistance)) {
+        score += Math.max(0, 90 - keywordDistance);
+    }
+    if (/(验证码|校验码|动态码|一次性代码|登录代码|安全代码)/.test(context)) {
+        score += 20;
+    }
+    if (/(openai|chatgpt|google|github|telegram|microsoft|apple|discord|cloudflare)/i.test(context)) {
+        score += 15;
+    }
+    if (/\b(code|pin|otp)\b\s*(?:is|:|：|-)/i.test(context) || /(?:验证码|代码|校验码|动态码)\s*(?:是|为|:|：)/.test(context)) {
+        score += 55;
+    }
+    if (/(?:expires?|expire|valid|有效|过期|分钟|minutes?|mins?)/i.test(context)) {
+        score += 5;
+    }
+    if (isLikelyDateOrTime(code, context)) {
+        score -= 100;
+    }
+
+    score -= Math.min(index / 100, 15);
+    return score;
+};
+
+export const extractVerificationCode = (input: string): string => {
+    const normalized = decodeHtmlEntities(input)
+        .replace(/[\u200B-\u200D\uFEFF]/g, "")
+        .replace(/[０-９]/g, char => String.fromCharCode(char.charCodeAt(0) - 0xFEE0));
+    const candidates: { code: string; score: number; index: number }[] = [];
+    const seen = new Set<string>();
+    const codePattern = /(?<!\d)(?:\d[\s\-_.:：]?){4,8}\d?(?!\d)/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = codePattern.exec(normalized)) !== null) {
+        const code = compactCandidateCode(match[0]);
+        if (!/^\d{4,8}$/.test(code) || seen.has(code)) {
+            continue;
+        }
+        const start = Math.max(0, match.index - MAX_CODE_CONTEXT_LENGTH);
+        const end = Math.min(normalized.length, match.index + match[0].length + MAX_CODE_CONTEXT_LENGTH);
+        const context = normalized.slice(start, end);
+        const score = scoreCandidate(code, context, match.index, match.index - start);
+        if (score > 0) {
+            candidates.push({ code, score, index: match.index });
+            seen.add(code);
+        }
+    }
+
+    candidates.sort((a, b) => b.score - a.score || a.index - b.index);
+    return candidates[0]?.code || "";
+};


### PR DESCRIPTION
## Summary
- Add Telegram mail preview fallback from HTML bodies to readable plain text.
- Extract likely 4-8 digit verification codes from subject/text/HTML and show them first.
- Cover spaced, separated, entity-encoded, 4-digit, 6-digit, and 8-digit code formats.
- Keep changelogs updated in Chinese and English.

## Test Plan
- `node --test src/telegram_api/verification_code.test.ts`
- `corepack pnpm lint`
- `corepack pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进 Telegram 推送通知中的电子邮件内容处理：当仅有 HTML 时可回退到纯文本，优先识别并突出显示 4–8 位验证码，并兼容常见分隔格式与 HTML 实体，避免在小程序中只显示“解析失败”类信息。

* **测试**
  * 新增验证码提取与 HTML 转纯文本相关的测试覆盖。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dreamhunter2333/cloudflare_temp_email/pull/1034)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->