### PR TITLE
feat: add AI extract webhook placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - feat: |Telegram| Telegram 新邮件推送与 `/mails` 历史邮件查看支持展示 AI 提取结果，包含验证码、验证链接、服务链接、订阅链接等关键信息
+- feat: |Webhook| 邮件 Webhook 模板支持填充 AI 提取结果占位符，包括 `aiExtractType`、`aiExtractResult`、`aiExtractResultText`
 - feat: |Frontend| 新增 `DISABLE_SHOW_GITHUB_FOR_USER` 配置，可仅对普通用户隐藏 Header 的 GitHub/版本入口，admin 仍可见（issue #1041）
 - feat: |Frontend| 将邮箱地址凭证弹窗升级为“地址凭证与连接方式”，复用普通用户与 admin 创建邮箱结果弹窗；支持通过 `ENABLE_AGENT_EMAIL_INFO` 展示 AI Agent 接入信息，并通过 `SMTP_IMAP_PROXY_CONFIG` 展示 SMTP/IMAP 客户端连接信息
 - docs: |随机子域名| 在前端“启用随机子域名”提示与 `subdomain` / `worker-vars` 文档（中英）中明确说明：要让 `name@<随机>.abc.com` 真正收到邮件，必须在基础域名 DNS 中为 `*` 子域添加通配 MX 记录，Email Routing 子域不继承父域配置（issue #1035）

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -11,6 +11,7 @@
 ### Features
 
 - feat: |Telegram| Show AI extraction results in Telegram new-mail notifications and `/mails` history views, including verification codes, auth links, service links, and subscription links
+- feat: |Webhook| Support AI extraction placeholders in mail webhook templates, including `aiExtractType`, `aiExtractResult`, and `aiExtractResultText`
 - feat: |Frontend| Add `DISABLE_SHOW_GITHUB_FOR_USER` to hide the Header GitHub/version entry from normal users while keeping it visible to admin users (issue #1041)
 - feat: |Frontend| Upgrade the address credential dialog to "Address Credentials & Connection Methods" and reuse it for both normal users and admin-created addresses; support showing AI Agent access via `ENABLE_AGENT_EMAIL_INFO` and SMTP/IMAP client settings via `SMTP_IMAP_PROXY_CONFIG`
 - docs: |Random Subdomain| Clarify in the "Use Random Subdomain" frontend tip and the `subdomain` / `worker-vars` docs (zh & en) that receiving mail on `name@<random>.abc.com` requires a wildcard `*` MX record under the base domain in DNS, because Cloudflare Email Routing does not inherit the apex configuration onto subdomains (issue #1035)

--- a/e2e/tests/api/webhook-trigger.spec.ts
+++ b/e2e/tests/api/webhook-trigger.spec.ts
@@ -72,6 +72,9 @@ test.describe('Webhook — triggered on incoming mail', () => {
             from: '${from}',
             to: '${to}',
             subject: '${subject}',
+            aiExtractType: '${aiExtractType}',
+            aiExtractResult: '${aiExtractResult}',
+            aiExtractResultText: '${aiExtractResultText}',
           }),
         },
       });
@@ -93,7 +96,16 @@ test.describe('Webhook — triggered on incoming mail', () => {
       ].join('\r\n');
 
       const res = await request.post(`${WORKER_URL}/admin/test/receive_mail`, {
-        data: { from, to: address, raw },
+        data: {
+          from,
+          to: address,
+          raw,
+          ai_extract_result: {
+            type: 'auth_code',
+            result: '654321',
+            result_text: 'Login verification code',
+          },
+        },
       });
       expect(res.ok()).toBe(true);
 
@@ -106,6 +118,9 @@ test.describe('Webhook — triggered on incoming mail', () => {
       expect(payload.from).toContain('webhook-sender@test.example.com');
       expect(payload.to).toBe(address);
       expect(payload.subject).toBe(subject);
+      expect(payload.aiExtractType).toBe('auth_code');
+      expect(payload.aiExtractResult).toBe('654321');
+      expect(payload.aiExtractResultText).toBe('Login verification code');
     } finally {
       server.close();
     }

--- a/vitepress-docs/docs/en/guide/feature/webhook.md
+++ b/vitepress-docs/docs/en/guide/feature/webhook.md
@@ -111,5 +111,10 @@ To get the url, you need to configure the worker's `FRONTEND_URL` to your fronte
     "raw": "${raw}",
     "parsedText": "${parsedText}",
     "parsedHtml": "${parsedHtml}",
+    "aiExtractType": "${aiExtractType}",
+    "aiExtractResult": "${aiExtractResult}",
+    "aiExtractResultText": "${aiExtractResultText}",
 }
 ```
+
+When AI email extraction is enabled, webhook templates can use the `aiExtractType`, `aiExtractResult`, and `aiExtractResultText` placeholders. They are empty strings when no extraction result is available.

--- a/vitepress-docs/docs/zh/guide/feature/webhook.md
+++ b/vitepress-docs/docs/zh/guide/feature/webhook.md
@@ -111,5 +111,10 @@
     "raw": "${raw}",
     "parsedText": "${parsedText}",
     "parsedHtml": "${parsedHtml}",
+    "aiExtractType": "${aiExtractType}",
+    "aiExtractResult": "${aiExtractResult}",
+    "aiExtractResultText": "${aiExtractResultText}",
 }
 ```
+
+启用 AI 邮件内容提取后，Webhook 模板可使用 `aiExtractType`、`aiExtractResult`、`aiExtractResultText` 占位符。未提取到结果时这些字段为空字符串。

--- a/worker/src/admin_api/mail_webhook_settings.ts
+++ b/worker/src/admin_api/mail_webhook_settings.ts
@@ -37,7 +37,11 @@ async function testWebhookSettings(c: Context<HonoCustomType>): Promise<Response
         subject: parsedEmail?.subject || "test subject",
         raw: raw || "test raw email",
         parsedText: parsedEmail?.text || "test parsed text",
-        parsedHtml: parsedEmail?.html || "test parsed html"
+        parsedHtml: parsedEmail?.html || "test parsed html",
+        aiExtract: null,
+        aiExtractType: "",
+        aiExtractResult: "",
+        aiExtractResultText: ""
     });
     if (!res.success) {
         return c.text(res.message || "send webhook error", 400);

--- a/worker/src/common.ts
+++ b/worker/src/common.ts
@@ -5,7 +5,7 @@ import { WorkerMailerOptions } from 'worker-mailer';
 import { getBooleanValue, getDomains, getStringArray, getStringValue, getIntValue, getUserRoles, getDefaultDomains, getJsonSetting, getAnotherWorkerList, hashPassword, getJsonObjectValue, getRandomSubdomainDomains, getDomainMapValue, normalizeDomains, trimLower } from './utils';
 import { unbindTelegramByAddress } from './telegram_api/common';
 import { CONSTANTS } from './constants';
-import { AddressCreationSettings, AdminWebhookSettings, WebhookMail, WebhookSettings } from './models';
+import { AddressCreationSettings, AdminWebhookSettings, ExtractResult, WebhookMail, WebhookSettings } from './models';
 import i18n from './i18n';
 
 const DEFAULT_NAME_REGEX = /[^a-z0-9]/g;
@@ -810,7 +810,8 @@ export async function triggerWebhook(
     c: Context<HonoCustomType>,
     address: string,
     parsedEmailContext: ParsedEmailContext,
-    message_id: string | null
+    message_id: string | null,
+    aiExtract?: ExtractResult | null
 ): Promise<void> {
     if (!c.env.KV || !getBooleanValue(c.env.ENABLE_WEBHOOK)) {
         return
@@ -843,6 +844,9 @@ export async function triggerWebhook(
     ).bind(address, message_id).first<string>("id");
 
     const parsedEmail = await commonParseMail(parsedEmailContext);
+    const usableAiExtract = aiExtract?.type !== "none" && aiExtract?.result
+        ? aiExtract
+        : null;
     const webhookMail = {
         id: mailId || "",
         url: c.env.FRONTEND_URL ? `${c.env.FRONTEND_URL}?mail_id=${mailId}` : "",
@@ -852,6 +856,10 @@ export async function triggerWebhook(
         raw: parsedEmailContext.rawEmail || "",
         parsedText: parsedEmail?.text || "",
         parsedHtml: parsedEmail?.html || "",
+        aiExtract: usableAiExtract,
+        aiExtractType: usableAiExtract?.type || "",
+        aiExtractResult: usableAiExtract?.result || "",
+        aiExtractResultText: usableAiExtract?.result_text || "",
     }
     for (const settings of webhookList) {
         const res = await sendWebhook(settings, webhookMail);

--- a/worker/src/email/index.ts
+++ b/worker/src/email/index.ts
@@ -138,7 +138,7 @@ async function email(message: ForwardableEmailMessage, env: Bindings, ctx: Execu
     try {
         await triggerWebhook(
             { env: env } as Context<HonoCustomType>,
-            toAddress, parsedEmailContext, message_id
+            toAddress, parsedEmailContext, message_id, aiExtractResult
         );
     } catch (error) {
         console.error("send webhook error", error);

--- a/worker/src/mails_api/webhook_settings.ts
+++ b/worker/src/mails_api/webhook_settings.ts
@@ -53,7 +53,11 @@ async function testWebhookSettings(c: Context<HonoCustomType>): Promise<Response
         subject: parsedEmail?.subject || "test subject",
         raw: raw || "test raw email",
         parsedText: parsedEmail?.text || "test parsed text",
-        parsedHtml: parsedEmail?.html || "test parsed html"
+        parsedHtml: parsedEmail?.html || "test parsed html",
+        aiExtract: null,
+        aiExtractType: "",
+        aiExtractResult: "",
+        aiExtractResultText: ""
     });
     if (!res.success) {
         return c.text(res.message || "send webhook error", 400);

--- a/worker/src/models/index.ts
+++ b/worker/src/models/index.ts
@@ -32,6 +32,10 @@ export type WebhookMail = {
     raw: string;
     parsedText: string;
     parsedHtml: string;
+    aiExtract: ExtractResult | null;
+    aiExtractType: string;
+    aiExtractResult: string;
+    aiExtractResultText: string;
 }
 
 export type CustomSqlCleanup = {
@@ -156,6 +160,9 @@ export class WebhookSettings {
         "raw": "${raw}",
         "parsedText": "${parsedText}",
         "parsedHtml": "${parsedHtml}",
+        "aiExtractType": "${aiExtractType}",
+        "aiExtractResult": "${aiExtractResult}",
+        "aiExtractResultText": "${aiExtractResultText}",
     }, null, 2)
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- cover realtime email -> AI extraction -> Telegram push text in e2e
- pass an E2E-only mockBot through ExecutionContext.props and only use it when E2E_TEST_MODE is enabled
- keep production Telegram bot creation inside sendMailToTelegram

## Checks
- pnpm lint (worker)
- pnpm build (worker)
- git diff --check
- pnpm exec playwright test --list tests/api/telegram-ai-extract.spec.ts


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Assert Telegram sendMessage payload in E2E

- Configure Telegram global mail push settings

- Pass E2E-only mock bot via ExecutionContext

- Route Telegram sending through injected bot


___

### Diagram Walkthrough


```mermaid
flowchart LR
  testSpec["Playwright test"] --> settingsAPI["POST /admin/telegram/settings"]
  testSpec --> receiveAPI["POST /e2e/test/receiveMail (receiveMail)"]
  receiveAPI --> emailHandler["worker email handler"]
  emailHandler --> sendMail["sendMailToTelegram(..., mockBot)"]
  sendMail --> bot["mockBot.telegram.sendMessage"]
  bot --> assert["assert telegramMessages + metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>telegram-ai-extract.spec.ts</strong><dd><code>Verify Telegram AI extraction sendMessage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/tests/api/telegram-ai-extract.spec.ts

<ul><li>Enable global mail push via admin API<br> <li> Trigger realtime AI extraction test flow<br> <li> Assert one Telegram message payload contents<br> <li> Disable global mail push in cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1046/files#diff-44c69b0ed9bf2e760246ac0749b98f1553930309b7cae1b1da7a56e7f844598e">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_test_api.ts</strong><dd><code>Capture Telegram payload via E2E mockBot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/admin_api/e2e_test_api.ts

<ul><li>Add <code>telegramMessages</code> array to response<br> <li> Inject E2E-only AI extract env override<br> <li> Provide <code>mockBot.telegram.sendMessage</code> spy<br> <li> Pass <code>mockBot</code> through <code>ExecutionContext.props</code></ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1046/files#diff-bc6e881531c1adc81550eb9aaa722f5cf5aae5e06ec3749f6d182d68b7ee0438">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Forward mockBot to Telegram sender</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/email/index.ts

<ul><li>Read <code>mockBot</code> from <code>ctx.props</code><br> <li> Extend <code>sendMailToTelegram</code> call signature<br> <li> Keep normal production behavior unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1046/files#diff-da1768152a73f37b0a0780d578569f84c3d4bb946294e3a81fb0271302e6d816">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>telegram.ts</strong><dd><code>Use injected mockBot for E2E mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/telegram_api/telegram.ts

<ul><li>Extend <code>sendMailToTelegram</code> function parameters<br> <li> Select bot based on <code>E2E_TEST_MODE</code> and <code>mockBot</code><br> <li> Keep real <code>newTelegramBot</code> for production</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1046/files#diff-a62d9c6ad0b04691396db4eecb38680ea80a2690f021e18baa6012ad525a27d3">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * Webhook 模板现支持使用 AI 邮件提取结果字段，包括提取类型、提取结果和结果文本三个占位符。

* **文档**
  * 更新 Webhook 数据格式文档，详细说明新增 AI 提取字段的含义和使用方法。

* **测试**
  * 新增端到端测试验证 Webhook 正确传递 AI 提取数据。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dreamhunter2333/cloudflare_temp_email/pull/1046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->