### PR TITLE
fix: add page header padding for mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug Fixes
 
 - fix: |AI 提取| HTML-only 邮件在发送给 Workers AI 前会先压缩为可读文本，避免样式模板过长导致验证码位于 4000 字截断之后而无法识别
+- fix: |Frontend| 移动端 Header 增加页头内边距，避免标题、菜单按钮与屏幕边缘过近
 
 ### Improvements
 

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -13,6 +13,7 @@
 ### Bug Fixes
 
 - fix: |AI Extract| Convert HTML-only mail bodies into compact readable text before sending them to Workers AI, preventing long templates from pushing verification codes past the 4000-character truncation window
+- fix: |Frontend| Add mobile Header page padding so the title and menu button no longer sit too close to the screen edge
 
 ### Improvements
 

--- a/frontend/src/views/Header.vue
+++ b/frontend/src/views/Header.vue
@@ -337,10 +337,6 @@ onMounted(async () => {
     justify-content: space-between;
 }
 
-:deep(.n-page-header) {
-    padding: 10px;
-}
-
 .header-extra {
     align-items: center;
     flex-wrap: nowrap;
@@ -439,6 +435,10 @@ onMounted(async () => {
 }
 
 @media (max-width: 640px) {
+    :deep(.n-page-header) {
+        padding: 10px;
+    }
+
     :deep(.n-page-header__title) {
         min-width: 0;
     }

--- a/frontend/src/views/Header.vue
+++ b/frontend/src/views/Header.vue
@@ -337,6 +337,10 @@ onMounted(async () => {
     justify-content: space-between;
 }
 
+:deep(.n-page-header) {
+    padding: 10px;
+}
+
 .header-extra {
     align-items: center;
     flex-wrap: nowrap;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式**
  * 为移动端页面头部增加内边距，避免标题与菜单按钮过于靠近屏幕边缘，改善触控与视觉体验。
  * 仅为样式层面的视觉调整，不影响脚本逻辑或组件行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->