### PR TITLE
fix: compact HTML before AI email extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- fix: |AI 提取| HTML-only 邮件在发送给 Workers AI 前会先压缩为可读文本，避免样式模板过长导致验证码位于 4000 字截断之后而无法识别
+
 ### Improvements
 
 ## v1.9.0

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- fix: |AI Extract| Convert HTML-only mail bodies into compact readable text before sending them to Workers AI, preventing long templates from pushing verification codes past the 4000-character truncation window
+
 ### Improvements
 
 ## v1.9.0

--- a/worker/src/email/ai_extract.ts
+++ b/worker/src/email/ai_extract.ts
@@ -166,6 +166,65 @@ async function saveExtractMetadata(
     }
 }
 
+function decodeHtmlEntities(text: string): string {
+    const entities: Record<string, string> = {
+        amp: '&',
+        lt: '<',
+        gt: '>',
+        quot: '"',
+        apos: "'",
+        nbsp: ' ',
+    };
+
+    const decodeCodePoint = (value: number, fallback: string) => {
+        if (!Number.isFinite(value) || value < 0 || value > 0x10ffff) {
+            return fallback;
+        }
+        return String.fromCodePoint(value);
+    };
+
+    return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/gi, (match, entity) => {
+        const normalized = entity.toLowerCase();
+        if (normalized.startsWith('#x')) {
+            const value = Number.parseInt(normalized.slice(2), 16);
+            return decodeCodePoint(value, match);
+        }
+        if (normalized.startsWith('#')) {
+            const value = Number.parseInt(normalized.slice(1), 10);
+            return decodeCodePoint(value, match);
+        }
+        return entities[normalized] ?? match;
+    });
+}
+
+function htmlToTextForAi(html: string): string {
+    return decodeHtmlEntities(
+        html
+            .replace(/<\s*(script|style|head|svg)[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, ' ')
+            .replace(/<!--[\s\S]*?-->/g, ' ')
+            .replace(/<a\b[^>]*\bhref=(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi, ' $3 $2 ')
+            .replace(/<\s*br\s*\/?>/gi, '\n')
+            .replace(/<\/\s*(p|div|tr|td|th|li|table|section|article|header|footer|h[1-6])\s*>/gi, '\n')
+            .replace(/<[^>]+>/g, ' ')
+    )
+        .replace(/[ \t\r\f\v]+/g, ' ')
+        .replace(/\n\s+/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+function getEmailContentForExtract(parsedEmail: Awaited<ReturnType<typeof commonParseMail>>): string {
+    if (parsedEmail?.text) {
+        return parsedEmail.text;
+    }
+
+    if (!parsedEmail?.html) {
+        return "";
+    }
+
+    return htmlToTextForAi(parsedEmail.html) || parsedEmail.html;
+}
+
 /**
  * Main extraction function
  * Checks if extraction is enabled, processes the email content, and saves to database.
@@ -219,7 +278,7 @@ export async function extractEmailInfo(
 
         // Parse email to get content (shared by the AI path and the regex fallback)
         const parsedEmail = await commonParseMail(parsedEmailContext);
-        const emailContent = parsedEmail?.text || parsedEmail?.html || "";
+        const emailContent = getEmailContentForExtract(parsedEmail);
 
         if (!emailContent) {
             return null;


### PR DESCRIPTION
### **User description**
## Summary
- Convert HTML-only email bodies into compact readable text before sending content to Workers AI
- Preserve link hrefs in the compact text so link extraction still has URL context
- Keep plain text bodies unchanged and retain the existing 4000-character truncation after compaction

## Verification
- `cd worker && pnpm lint`
- `cd worker && pnpm build`
- Local reproduction with `/Users/dreamhunter/Downloads/2373965.eml`: PostalMime HTML-only body compacts from 8618 chars to 1208 chars, with code `509632` at index 13
- Remote Workers AI preview using `@cf/meta/llama-3.1-8b-instruct-fast` returned `{ type: "auth_code", result: "509632", result_text: "" }` for the compacted body


___

### **PR Type**
Bug fix


___

### **Description**
- Compact HTML-only bodies before AI extraction

- Decode HTML entities for readable output

- Strip scripts/styles/comments and normalize links

- Use compacted text for AI/regex extraction


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parse email content"] --> B["Check parsed text availability"]
  B -- "Has text" --> C["Use plain parsedEmail.text"]
  B -- "No text, has HTML" --> D["Convert HTML to compact text"]
  D --> E["Send compact text to Workers AI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai_extract.ts</strong><dd><code>Compact HTML-only email bodies for AI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker/src/email/ai_extract.ts

<ul><li>Add <code>decodeHtmlEntities</code> to decode common entities<br> <li> Add <code>htmlToTextForAi</code> HTML→text compaction pipeline<br> <li> Add <code>getEmailContentForExtract</code> content selection logic<br> <li> Switch extraction to use compacted HTML text</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1057/files#diff-ee497ce196c1588a7c70e4d40adcf1573c93c2846992206fd0e7a0854fc554b6">+60/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document HTML compaction bug fix (ZH)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add bug-fix entry for HTML compaction before AI


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1057/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Document HTML compaction bug fix (EN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG_EN.md

- Add bug-fix entry describing AI Extract HTML compaction


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1057/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了邮件内容被截断导致关键信息（如验证码）无法被识别的问题。现已在AI处理HTML邮件前，将其转换为更紧凑的文本格式，确保完整内容被识别。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1058
