### PR TITLE
fix: harden remote content policy edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| 关闭邮件外部图片自动加载时保留 `<a>` 与 `<area>` 的外部导航链接，并阻断通过 CSS 转义函数名或 at-rule 绕过远程资源过滤的情况
 - fix: |Frontend| 使用共享 DOMPurify 净化逻辑处理关于页面与启动通知中的 HTML 公告，避免 `ANNOUNCEMENT` 中的可执行标签或事件属性造成 XSS
 - fix: |Worker| 按邮件认证规范修复垃圾邮件检测：SPF、DKIM、DMARC 的 `none` 及 SPF/DKIM `neutral` 按认证方法不存在处理，并忽略未注册结果和不支持的方法版本；`JUNK_MAIL_FORCE_PASS_LIST` 仍要求明确返回受支持的 `pass`
 - fix: |Admin| 管理后台删除邮箱地址时，先删除该地址的邮件、发件记录、自动回复等关联数据，最后再删除地址本身；此前地址行先被删除导致按地址名匹配的子查询查不到数据，邮件等记录被遗留在数据库中

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| Preserve external navigation links on `<a>` and `<area>` elements when automatic remote-image loading is disabled, and block remote CSS resources hidden behind escaped function or at-rule names
 - fix: |Frontend| Sanitize HTML announcements in both the About page and startup notification through a shared DOMPurify helper, preventing executable tags or event attributes in `ANNOUNCEMENT` from causing XSS
 - fix: |Worker| Align junk-mail checking with authentication standards: treat SPF, DKIM, and DMARC `none` plus SPF/DKIM `neutral` as absent, and ignore unregistered results and unsupported method versions; `JUNK_MAIL_FORCE_PASS_LIST` still requires an explicit supported `pass`
 - fix: |Admin| When deleting an address from the admin panel, delete its mails, sender records, sendbox and auto-reply entries before removing the address row itself; previously the address row was deleted first, so the name-based subqueries matched nothing and the mails were left orphaned in the database

--- a/frontend/src/utils/__tests__/remote-content-policy.test.js
+++ b/frontend/src/utils/__tests__/remote-content-policy.test.js
@@ -38,6 +38,9 @@ const V = [
     ['style 誘餌 url(', `<style>.a{content:"url(";background:url(${T})}</style>`],
     ['attr image-set', `<div style="background:image-set('${T}' 1x)">x</div>`],
     ['attr CSS 跳脫', `<div style="background:url(\\68 ttps://tracker.example/p.png)">x</div>`],
+    ['attr CSS 函式名稱跳脫', `<div style="background:u\\72l(${T})">x</div>`],
+    ['style CSS 函式名稱跳脫', `<style>.a{background:u\\72l(${T})}</style>`],
+    ['style CSS at-rule 跳脫', `<style>@im\\70ort "${T}";</style>`],
     ['URL 反斜線', `<img src="https:\\\\tracker.example\\p.png">`],
     ['scheme 無斜線', `<img src="https:tracker.example/p.png">`],
     ['data:text/html iframe', `<iframe src="data:text/html,&lt;img src=${T}&gt;"></iframe>`],
@@ -63,6 +66,8 @@ const KEEP = [
     ['排版 CSS', '<table><tr><td style="padding:8px;color:#333">hi</td></tr></table>', 'padding:8px'],
     ['style 區塊排版', '<style>.a{color:red;font-size:14px}</style><p class="a">x</p>', 'font-size:14px'],
     ['data: 於 CSS', '<div style="background:url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBTAA7)">x</div>', 'data:image/gif'],
+    ['外部 a 連結', `<a href="${T}">open</a>`, T],
+    ['外部 area 連結', `<map name="m"><area href="${T}" coords="0,0,1,1"></map>`, T],
 ];
 
 describe('攻擊向量', () => {

--- a/frontend/src/utils/__tests__/remote-content-policy.test.js
+++ b/frontend/src/utils/__tests__/remote-content-policy.test.js
@@ -83,4 +83,24 @@ describe('必須保留', () => {
         expect({ v: n, kept: r.html.includes(needle), blocked: r.blocked })
             .toEqual({ v: n, kept: true, blocked: 0 });
     });
+
+    it('保留安全 CSS 跳脫與本地資源', () => {
+        const r = blockRemoteContent(
+            '<div style="font-family:\\41 rial;background:url(data:image/gif;base64,AAAA)">x</div>'
+        );
+        expect(r.blocked).toBe(0);
+        expect(r.html).toContain('font-family:\\41 rial');
+        expect(r.html).toContain('data:image/gif');
+    });
+});
+
+describe('阻斷計數', () => {
+    it('逐一計算 CSS 跳脫函式中的遠端資源', () => {
+        const r = blockRemoteContent(
+            '<div style="color:red;background:u\\72l(https://a.example/a.png),u\\72l(https://b.example/b.png)">x</div>'
+        );
+        expect(r.blocked).toBe(2);
+        expect(r.html).toContain('color:red');
+        expect(r.html).not.toContain('https://');
+    });
 });

--- a/frontend/src/utils/__tests__/remote-content-policy.test.js
+++ b/frontend/src/utils/__tests__/remote-content-policy.test.js
@@ -104,3 +104,18 @@ describe('阻斷計數', () => {
         expect(r.html).not.toContain('https://');
     });
 });
+
+describe('危險導航協議', () => {
+    it.each([
+        ['a javascript', '<a href="javascript:alert(1)">x</a>', 'a'],
+        ['a data:text/html', '<a href="data:text/html,<script>alert(1)</script>">x</a>', 'a'],
+        ['area javascript', '<map><area href="javascript:alert(1)"></map>', 'area'],
+        ['area data:text/html', '<map><area href="data:text/html,<script>alert(1)</script>"></map>', 'area'],
+    ])('%s', (_name, html, selector) => {
+        const host = document.createElement('div');
+        host.innerHTML = blockRemoteContent(html).html;
+        const node = host.querySelector(selector);
+        expect(node).not.toBeNull();
+        expect(node.hasAttribute('href')).toBe(false);
+    });
+});

--- a/frontend/src/utils/remote-content-policy.js
+++ b/frontend/src/utils/remote-content-policy.js
@@ -31,6 +31,12 @@ const CSS_FETCHES = /url\(|image-set|image\(|cross-fade|element\(|@import/i;
 // A url(...) token or a bare string, either of which can name a resource.
 const CSS_TOKEN = /url\(\s*(['"]?)([^'")]*)\1\s*\)|(['"])([^'"]*)\3/g;
 const CSS_ESCAPE = /\\([0-9a-f]{1,6})[ \t\r\n\f]?|\\([^\r\n\f0-9a-f])/gi;
+const CSS_ESCAPED_IDENTIFIER =
+    /@?(?:[-_a-z0-9]|\\(?:[0-9a-f]{1,6}[ \t\r\n\f]?|[^\r\n\f0-9a-f]))+/gi;
+const CSS_FETCH_IDENTIFIERS = new Set([
+    'url', 'image-set', '-webkit-image-set', 'image', 'cross-fade',
+    '-webkit-cross-fade', 'element', '-moz-element', '@import',
+]);
 
 function decodeCssEscapes(value) {
     return value.replace(CSS_ESCAPE, (_match, hex, escaped) => {
@@ -43,6 +49,16 @@ function decodeCssEscapes(value) {
             return '\uFFFD';
         }
         return String.fromCodePoint(codePoint);
+    });
+}
+
+function normalizeCssFetchIdentifiers(value) {
+    return value.replace(CSS_ESCAPED_IDENTIFIER, (identifier) => {
+        if (!identifier.includes('\\')) {
+            return identifier;
+        }
+        const decoded = decodeCssEscapes(identifier);
+        return CSS_FETCH_IDENTIFIERS.has(decoded.toLowerCase()) ? decoded : identifier;
     });
 }
 
@@ -90,15 +106,11 @@ function srcsetIsLocal(value) {
  * dropped, so the surrounding rule structure survives.
  */
 function blockCssUrls(cssText, onBlocked) {
-    const decodedCssText = decodeCssEscapes(cssText);
-    if (!CSS_FETCHES.test(decodedCssText)) {
+    const normalizedCssText = normalizeCssFetchIdentifiers(cssText);
+    if (!CSS_FETCHES.test(normalizedCssText)) {
         return cssText;
     }
-    if (decodedCssText !== cssText) {
-        onBlocked();
-        return '';
-    }
-    return cssText.replace(CSS_TOKEN, (match, urlQuote, urlValue, strQuote, strValue) => {
+    return normalizedCssText.replace(CSS_TOKEN, (match, urlQuote, urlValue, strQuote, strValue) => {
         const isUrlToken = urlValue !== undefined;
         const token = isUrlToken ? urlValue : strValue;
         if (provablyLocal(token)) {

--- a/frontend/src/utils/remote-content-policy.js
+++ b/frontend/src/utils/remote-content-policy.js
@@ -8,6 +8,7 @@ const URL_ATTRIBUTES = new Set([
     'src', 'srcset', 'imagesrcset', 'href', 'xlink:href',
     'poster', 'background', 'data', 'action', 'formaction',
 ]);
+const NAVIGATION_HREF_ELEMENTS = new Set(['A', 'AREA']);
 
 // Elements that fetch on their own, redirect the frame, or re-base every
 // relative URL in the document. None of them belong in a mail body, and
@@ -29,6 +30,21 @@ const ALLOWED_URI_REGEXP =
 const CSS_FETCHES = /url\(|image-set|image\(|cross-fade|element\(|@import/i;
 // A url(...) token or a bare string, either of which can name a resource.
 const CSS_TOKEN = /url\(\s*(['"]?)([^'")]*)\1\s*\)|(['"])([^'"]*)\3/g;
+const CSS_ESCAPE = /\\([0-9a-f]{1,6})[ \t\r\n\f]?|\\([^\r\n\f0-9a-f])/gi;
+
+function decodeCssEscapes(value) {
+    return value.replace(CSS_ESCAPE, (_match, hex, escaped) => {
+        if (!hex) {
+            return escaped;
+        }
+        const codePoint = Number.parseInt(hex, 16);
+        if (codePoint === 0 || codePoint > 0x10FFFF ||
+            (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+            return '\uFFFD';
+        }
+        return String.fromCodePoint(codePoint);
+    });
+}
 
 /**
  * Whether a URL can be *proven* to stay off the network.
@@ -74,8 +90,13 @@ function srcsetIsLocal(value) {
  * dropped, so the surrounding rule structure survives.
  */
 function blockCssUrls(cssText, onBlocked) {
-    if (!CSS_FETCHES.test(cssText)) {
+    const decodedCssText = decodeCssEscapes(cssText);
+    if (!CSS_FETCHES.test(decodedCssText)) {
         return cssText;
+    }
+    if (decodedCssText !== cssText) {
+        onBlocked();
+        return '';
     }
     return cssText.replace(CSS_TOKEN, (match, urlQuote, urlValue, strQuote, strValue) => {
         const isUrlToken = urlValue !== undefined;
@@ -106,6 +127,9 @@ function getPurifier() {
 
     purifier.addHook('uponSanitizeAttribute', (node, data) => {
         if (!URL_ATTRIBUTES.has(data.attrName)) {
+            return;
+        }
+        if (data.attrName === 'href' && NAVIGATION_HREF_ELEMENTS.has(node.tagName)) {
             return;
         }
         const isSrcset = data.attrName === 'srcset' || data.attrName === 'imagesrcset';


### PR DESCRIPTION
### **User description**
## Summary

- preserve external navigation links on `<a>` and `<area>` while remote content blocking is enabled
- decode CSS escapes before resource detection and fail closed for escaped fetch constructs
- add regression coverage for escaped `url`/`@import` and navigation links
- update both changelogs

Follow-up to #1092.

## Verification

- `pnpm test` (60 passed)
- `pnpm build`
- `git diff --check`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Preserve external navigation links

- Decode CSS escapes before detection

- Block when decoded CSS mismatches

- Add regression tests for bypasses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["remote-content-policy.js: uponSanitizeAttribute"]
  B["Decode CSS escapes"]
  C["Remote detection (URLs/CSS)"]
  D["Allow navigation href for A/AREA"]
  E["Block CSS resource tokens"]
  F["remote-content-policy.test.js edge vectors"]
  A -- "Preserve href for `A`/`AREA`" --> D
  A -- "Sanitize CSS with decoded escapes" --> B
  B -- "Classify remote refs" --> C
  C -- "Replace blocked tokens/trigger block" --> E
  F -- "Validate bypass cases" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote-content-policy.test.js</strong><dd><code>Extend remote-content policy test vectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/utils/__tests__/remote-content-policy.test.js

<ul><li>Add CSS escape-based bypass attack vectors<br> <li> Add coverage for escaped function/at-rule names<br> <li> Add regression assertions for <code><a></code>/<code><area></code> external href</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1095/files#diff-b79e540764714a4d72c6d6abf0f1c98b65e5e8c954f676c0e414c5c2d2e941aa">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote-content-policy.js</strong><dd><code>Harden remote-content filtering edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/utils/remote-content-policy.js

<ul><li>Preserve <code>href</code> attributes on <code>A</code> and <code>AREA</code><br> <li> Add CSS escape decoding before resource checks<br> <li> Fail-closed if decoded CSS differs from original</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1095/files#diff-76eba57814abfde987762bc2ff8a34536bc2b3ff52953f3e5d7c3f4d71fb7734">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog entry for frontend remote policy fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document frontend fix for link preservation<br> <li> Note blocking of remote CSS via escaped constructs</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1095/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>English changelog entry for remote policy fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG_EN.md

<ul><li>Document preservation of external navigation<br> <li> Note blocking of escaped remote CSS resources</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1095/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 在“关闭邮件外部图片自动加载”模式下，保留外部跳转链接（`<a>` 与 `<area>`）的正常行为，避免被错误替换/阻断。
  - 加强远程资源拦截：对经 CSS 转义的资源触发与 `@import` 等变体进行识别与归一化，防止绕过并正确阻断远程 CSS 引用。
  - 危险导航协议会移除 `href`，不再允许 `javascript:`、`data:text/html` 等外链生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->