### PR TITLE
fix: 修复 Admin 二级标签页状态丢失

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Bug Fixes
 
+- fix: |Admin| 修复切换一级标签页时二级标签页偶发无选中项、内容不显示及指示条偏移的问题
+
 ### Improvements
 
 ### Testing

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -14,6 +14,8 @@
 
 ### Bug Fixes
 
+- fix: |Admin| Fix secondary tabs occasionally losing their active item, hiding content, and leaving the indicator offset after switching primary tabs
+
 ### Improvements
 
 ### Testing

--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -120,7 +120,7 @@ onMounted(async () => {
     </n-modal>
     <n-tabs v-if="showAdminPage" type="card" v-model:value="adminTab" :placement="globalTabplacement">
       <n-tab-pane name="qucickSetup" :tab="t('qucickSetup')">
-        <n-tabs type="bar" justify-content="center" animated>
+        <n-tabs key="quick-setup-tabs" type="bar" justify-content="center" animated>
           <n-tab-pane name="database" :tab="t('database')">
             <DatabaseManager />
           </n-tab-pane>
@@ -136,7 +136,7 @@ onMounted(async () => {
         </n-tabs>
       </n-tab-pane>
       <n-tab-pane name="account" :tab="t('account')">
-        <n-tabs type="bar" justify-content="center" animated>
+        <n-tabs key="account-tabs" type="bar" justify-content="center" animated>
           <n-tab-pane name="account" :tab="t('account')">
             <Account />
           </n-tab-pane>
@@ -161,7 +161,7 @@ onMounted(async () => {
         </n-tabs>
       </n-tab-pane>
       <n-tab-pane name="user" :tab="t('user')">
-        <n-tabs type="bar" justify-content="center" animated>
+        <n-tabs key="user-tabs" type="bar" justify-content="center" animated>
           <n-tab-pane name="user_management" :tab="t('user_management')">
             <UserManagement />
           </n-tab-pane>
@@ -177,7 +177,7 @@ onMounted(async () => {
         </n-tabs>
       </n-tab-pane>
       <n-tab-pane name="mails" :tab="t('mails')">
-        <n-tabs type="bar" justify-content="center" animated>
+        <n-tabs key="mails-tabs" type="bar" justify-content="center" animated>
           <n-tab-pane name="mails" :tab="t('mails')">
             <Mails />
           </n-tab-pane>
@@ -202,7 +202,7 @@ onMounted(async () => {
         <Statistics />
       </n-tab-pane>
       <n-tab-pane name="maintenance" :tab="t('maintenance')">
-        <n-tabs type="bar" justify-content="center" animated>
+        <n-tabs key="maintenance-tabs" type="bar" justify-content="center" animated>
           <n-tab-pane name="database" :tab="t('database')">
             <DatabaseManager />
           </n-tab-pane>


### PR DESCRIPTION
### **User description**
## 问题

Naive UI 2.45.0 在切换 Admin 一级标签页时会复用未受控的二级 Tabs 实例。当旧 active 值不属于新的标签集合时，二级标签页没有选中项、内容不显示，指示条仍停留在旧位置。

## 修改

- 为快速设置、账号、用户、邮件和维护的二级 Tabs 设置各自唯一的 key
- 切换一级标签页时重新创建对应二级 Tabs，恢复合法默认项及指示条位置
- 同步中英文 changelog

## 验证

- pnpm test：60 项通过
- pnpm build：通过
- 本地真实浏览器验证账号 → 维护：二级 active 为 database，可见内容 Pane 为 1，实例已重新创建


___

### **PR Type**
Bug fix


___

### **Description**
- Add unique `key` to admin nested Tabs

- Force secondary tabs re-creation on switch

- Prevent lost active item and offset

- Update Chinese/English changelogs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Admin primary n-tabs switch"] --> B["Secondary n-tabs re-created via unique key"]
  B --> C["Secondary active item restored"]
  B --> D["Indicator offset corrected"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Admin.vue</strong><dd><code>Fix Admin nested tabs state persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/Admin.vue

<ul><li>Add unique <code>key</code> props to nested <code>n-tabs</code> blocks<br> <li> Ensure secondary tabs remount when primary tab changes<br> <li> Stabilize active item selection and indicator placement</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1118/files#diff-78137b072a7fa52c6d503efb9a3d32c07da5073dd5ca32ac48b1402ac2481a55">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Admin nested tabs fix (CN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add <code>fix: |Admin|</code> bug fix entry<br> <li> Describe secondary tabs losing active state</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1118/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Document Admin nested tabs fix (EN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG_EN.md

<ul><li>Add <code>fix: |Admin|</code> bug fix entry<br> <li> Explain active loss, hidden content, offset issue</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1118/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复切换主标签页后，次级标签页偶发无活动项、内容不显示及指示器位置偏移的问题。
  * 提升嵌套标签页切换状态的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->