### PR TITLE
fix: load AdSense script without event attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| 修复 AdSense 脚本包含不受支持的 `data-onload` 和 `data-onerror` 属性
 - fix: |Admin| 修复权限设置加载完成前短暂显示管理员密码输入框的问题
 - fix: |Admin| 修复切换一级标签页时二级标签页偶发无选中项、内容不显示及指示条偏移的问题
 - fix: |发信页面| 统一邮箱与名称字段顺序，并修复空正文输入框的光标与占位文字错位

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+- fix: |Frontend| Remove unsupported `data-onload` and `data-onerror` attributes from the AdSense script
 - fix: |Admin| Avoid briefly showing the Admin password dialog before access settings finish loading
 - fix: |Admin| Fix secondary tabs occasionally losing their active item, hiding content, and leaving the indicator offset after switching primary tabs
 - fix: |Send Mail| Use a consistent address/name field order and align the empty content editor caret with its placeholder

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@ import {
   darkTheme,
 } from 'naive-ui'
 import { computed, onMounted, watchEffect } from 'vue'
-import { useScript } from '@unhead/vue'
+import { useHead } from '@unhead/vue'
 import { useI18n } from 'vue-i18n'
 import { useGlobalState } from './store'
 import { useIsMobile } from './utils/composables'
@@ -32,12 +32,13 @@ watchEffect(() => {
   document.documentElement.lang = isSupportedLocale(locale.value) ? locale.value : DEFAULT_LOCALE
 })
 
-// Load Google Ad script at top level (not inside onMounted)
 if (showAd.value) {
-  useScript({
-    src: `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adClient}`,
-    async: true,
-    crossorigin: "anonymous",
+  useHead({
+    script: [{
+      src: `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adClient}`,
+      async: true,
+      crossorigin: 'anonymous',
+    }],
   })
 }
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

- load the AdSense head script with useHead instead of useScript
- avoid unsupported data-onload and data-onerror attributes
- update the Chinese and English changelogs

## Validation

- frontend tests: 65 passed
- frontend production build passed
- verified in Chrome that the generated script has neither unsupported attribute


___

### **PR Type**
Bug fix


___

### **Description**
- Use `useHead` to inject AdSense script

- Remove unsupported event attributes from script


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Show ad enabled (showAd)"] --> B["Inject AdSense via useHead"]
  B --> C["Generate script with async and crossorigin only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Inject AdSense script via `useHead`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/App.vue

<ul><li>Replace <code>useScript</code> with <code>useHead</code> for AdSense injection<br> <li> Inject script using <code>script: [{ src, async, crossorigin }]</code><br> <li> Ensure no unsupported event attributes are emitted</ul>


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1136/files#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document AdSense attribute bug fix (中文)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add frontend bug fix entry for AdSense attributes


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1136/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG_EN.md</strong><dd><code>Document AdSense attribute bug fix (English)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG_EN.md

- Add English frontend bug fix entry for AdSense attributes


</details>


  </td>
  <td><a href="https://github.com/dreamhunter2333/cloudflare_temp_email/pull/1136/files#diff-77d2276dbbf8eb648363b81ea97049986b18e2cf1e90bd20fb5133ed5ff4fcae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 修复前端 AdSense 脚本包含不受支持的 `data-onload` 和 `data-onerror` 属性问题。
  * 优化 Google AdSense 脚本加载方式，保持异步加载及跨域配置不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->