### PR TITLE
fix(frontend): format created_at and updated_at with local date across admin views

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -19,7 +19,8 @@ export const getRouterPathWithLang = (path: string, lang: string) => {
     return getPathWithLocale(path, normalizedLang);
 }
 
-export const utcToLocalDate = (utcDate: string, useUTCDate: boolean) => {
+export const utcToLocalDate = (utcDate: string | null | undefined, useUTCDate: boolean) => {
+    if (!utcDate) return '';
     const utcDateString = `${utcDate} UTC`;
     if (useUTCDate) {
         return utcDateString;

--- a/frontend/src/views/admin/Account.vue
+++ b/frontend/src/views/admin/Account.vue
@@ -5,14 +5,15 @@ import { useScopedI18n } from '@/i18n/app'
 
 import { useGlobalState } from '../../store'
 import { api } from '../../api'
-import { hashPassword } from '../../utils'
+import { hashPassword, utcToLocalDate } from '../../utils'
 import { NButton, NMenu } from 'naive-ui';
 import { MenuFilled } from '@vicons/material'
 import AddressCredentialModal from '../../components/AddressCredentialModal.vue'
 
 const {
     loading, adminTab, openSettings,
-    adminMailTabAddress, adminSendBoxTabAddress
+    adminMailTabAddress, adminSendBoxTabAddress,
+    useUTCDate
 } = useGlobalState()
 const message = useMessage()
 
@@ -274,13 +275,19 @@ const columns = computed(() => [
         title: t('created_at'),
         key: "created_at",
         sorter: true,
-        sortOrder: sortBy.value === 'created_at' ? sortOrder.value : false
+        sortOrder: sortBy.value === 'created_at' ? sortOrder.value : false,
+        render(row) {
+            return utcToLocalDate(row.created_at, useUTCDate.value);
+        }
     },
     {
         title: t('updated_at'),
         key: "updated_at",
         sorter: true,
-        sortOrder: sortBy.value === 'updated_at' ? sortOrder.value : false
+        sortOrder: sortBy.value === 'updated_at' ? sortOrder.value : false,
+        render(row) {
+            return utcToLocalDate(row.updated_at, useUTCDate.value);
+        }
     },
     {
         title: t('source_meta'),

--- a/frontend/src/views/admin/SenderAccess.vue
+++ b/frontend/src/views/admin/SenderAccess.vue
@@ -4,8 +4,9 @@ import { useScopedI18n } from '@/i18n/app'
 
 import { useGlobalState } from '../../store'
 import { api } from '../../api'
+import { utcToLocalDate } from '../../utils';
 
-const { loading } = useGlobalState()
+const { loading, useUTCDate } = useGlobalState()
 const message = useMessage()
 
 const { t } = useScopedI18n('views.admin.SenderAccess')
@@ -70,7 +71,10 @@ const columns = [
   },
   {
     title: t('created_at'),
-    key: "created_at"
+    key: "created_at",
+    render(row) {
+      return utcToLocalDate(row.created_at, useUTCDate.value);
+    }
   },
   {
     title: t('balance'),

--- a/frontend/src/views/admin/UserManagement.vue
+++ b/frontend/src/views/admin/UserManagement.vue
@@ -6,11 +6,11 @@ import { MenuFilled } from '@vicons/material'
 
 import { useGlobalState } from '../../store'
 import { api } from '../../api'
-import { hashPassword } from '../../utils';
+import { hashPassword, utcToLocalDate } from '../../utils';
 
 import UserAddressManagement from './UserAddressManagement.vue'
 
-const { loading, openSettings } = useGlobalState()
+const { loading, openSettings, useUTCDate } = useGlobalState()
 const message = useMessage()
 
 const { t } = useScopedI18n('views.admin.UserManagement')
@@ -193,7 +193,10 @@ const columns = [
     },
     {
         title: t('created_at'),
-        key: "created_at"
+        key: "created_at",
+        render(row) {
+            return utcToLocalDate(row.created_at, useUTCDate.value);
+        }
     },
     {
         title: t('actions'),


### PR DESCRIPTION
## Summary of Changes
Fixes #1145.

This PR provides a comprehensive fix for local date/time rendering across all administrative table views:

1. **`frontend/src/views/admin/Account.vue`**:
   - Formatted `created_at` and `updated_at` with `utcToLocalDate(row.created_at, useUTCDate.value)` and `utcToLocalDate(row.updated_at, useUTCDate.value)`.
2. **`frontend/src/views/admin/UserManagement.vue`**:
   - Formatted `created_at` with `utcToLocalDate(row.created_at, useUTCDate.value)`.
3. **`frontend/src/views/admin/SenderAccess.vue`**:
   - Formatted `created_at` with `utcToLocalDate(row.created_at, useUTCDate.value)`.

## Motivation & Impact
- Eliminates inconsistent timestamp display where user-facing views formatted dates according to the local timezone/UTC toggle, but admin tables displayed raw naive UTC timestamps from the Cloudflare D1 database.
- Completely non-breaking; purely enhances visual presentation while fully respecting the user's global `useUTCDate` configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 管理后台账户地址、发件人访问和用户管理列表中的时间现可根据 UTC 配置转换为本地日期显示。
  * 缺少时间值时，相关日期字段将显示为空白，避免显示异常日期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->